### PR TITLE
Modernize Webapp auth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.0.11",
     "lucide-react": "^0.511.0",
     "next": "15.5.18",
-    "next-auth": "^4.24.11",
+    "next-auth": "5.0.0-beta.31",
     "next-i18next": "^15.4.2",
     "next-themes": "^0.4.6",
     "pg": "^8.20.0",
@@ -42,6 +42,8 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.18",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.0",
     "typescript": "^5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 15.5.18
         version: 15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
-        specifier: ^4.24.11
-        version: 4.24.11(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 5.0.0-beta.31
+        version: 5.0.0-beta.31(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       next-i18next:
         specifier: ^15.4.2
         version: 15.4.2(@types/react@19.1.4)(i18next@25.4.2(typescript@5.8.3))(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-i18next@15.7.3(i18next@25.4.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react@19.1.0)
@@ -108,6 +108,12 @@ importers:
       eslint-config-next:
         specifier: 15.5.18
         version: 15.5.18(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.27.0(jiti@2.4.2))
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@9.27.0(jiti@2.4.2))
       tailwindcss:
         specifier: ^4
         version: 4.1.7
@@ -127,6 +133,20 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@auth/core@0.41.2':
+    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
 
   '@babel/runtime@7.27.1':
     resolution: {integrity: sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==}
@@ -1658,10 +1678,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
   core-js@3.45.1:
     resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
 
@@ -2250,9 +2266,6 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  jose@4.15.9:
-    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
-
   jose@6.0.11:
     resolution: {integrity: sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==}
 
@@ -2373,10 +2386,6 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lru-cache@6.0.0:
-    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
-    engines: {node: '>=10'}
-
   lucide-react@0.511.0:
     resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
     peerDependencies:
@@ -2436,16 +2445,18 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next-auth@4.24.11:
-    resolution: {integrity: sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==}
+  next-auth@5.0.0-beta.31:
+    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
     peerDependencies:
-      '@auth/core': 0.34.2
-      next: ^12.2.5 || ^13 || ^14 || ^15
-      nodemailer: ^6.6.5
-      react: ^17.0.2 || ^18 || ^19
-      react-dom: ^17.0.2 || ^18 || ^19
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
     peerDependenciesMeta:
-      '@auth/core':
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
         optional: true
       nodemailer:
         optional: true
@@ -2486,16 +2497,12 @@ packages:
       sass:
         optional: true
 
-  oauth@0.9.15:
-    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2524,13 +2531,6 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
-
-  oidc-token-hash@5.1.0:
-    resolution: {integrity: sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==}
-    engines: {node: ^10.13.0 || >=12.0.0}
-
-  openid-client@5.7.1:
-    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2636,8 +2636,8 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  preact-render-to-string@5.2.6:
-    resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
     peerDependencies:
       preact: 10.26.10
 
@@ -2647,9 +2647,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  pretty-format@3.8.0:
-    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3032,10 +3029,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
@@ -3072,9 +3065,6 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -3109,6 +3099,14 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@auth/core@0.41.2':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.0.11
+      oauth4webapi: 3.8.6
+      preact: 10.26.10
+      preact-render-to-string: 6.5.11(preact@10.26.10)
 
   '@babel/runtime@7.27.1': {}
 
@@ -4658,8 +4656,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  cookie@0.7.2: {}
-
   core-js@3.45.1: {}
 
   cross-spawn@7.0.6:
@@ -5393,8 +5389,6 @@ snapshots:
 
   jiti@2.4.2: {}
 
-  jose@4.15.9: {}
-
   jose@6.0.11: {}
 
   js-tokens@4.0.0: {}
@@ -5492,10 +5486,6 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lru-cache@6.0.0:
-    dependencies:
-      yallist: 4.0.0
-
   lucide-react@0.511.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -5539,20 +5529,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-auth@4.24.11(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-auth@5.0.0-beta.31(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.27.1
-      '@panva/hkdf': 1.2.1
-      cookie: 0.7.2
-      jose: 4.15.9
+      '@auth/core': 0.41.2
       next: 15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      oauth: 0.9.15
-      openid-client: 5.7.1
-      preact: 10.26.10
-      preact-render-to-string: 5.2.6(preact@10.26.10)
       react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      uuid: 8.3.2
 
   next-i18next@15.4.2(@types/react@19.1.4)(i18next@25.4.2(typescript@5.8.3))(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-i18next@15.7.3(i18next@25.4.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react@19.1.0):
     dependencies:
@@ -5596,11 +5577,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  oauth@0.9.15: {}
+  oauth4webapi@3.8.6: {}
 
   object-assign@4.1.1: {}
-
-  object-hash@2.2.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -5641,15 +5620,6 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-
-  oidc-token-hash@5.1.0: {}
-
-  openid-client@5.7.1:
-    dependencies:
-      jose: 4.15.9
-      lru-cache: 6.0.0
-      object-hash: 2.2.0
-      oidc-token-hash: 5.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -5749,16 +5719,13 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  preact-render-to-string@5.2.6(preact@10.26.10):
+  preact-render-to-string@6.5.11(preact@10.26.10):
     dependencies:
       preact: 10.26.10
-      pretty-format: 3.8.0
 
   preact@10.26.10: {}
 
   prelude-ls@1.2.1: {}
-
-  pretty-format@3.8.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -6286,8 +6253,6 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  uuid@8.3.2: {}
-
   victory-vendor@36.9.2:
     dependencies:
       '@types/d3-array': 3.2.1
@@ -6355,8 +6320,6 @@ snapshots:
   word-wrap@1.2.5: {}
 
   xtend@4.0.2: {}
-
-  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -1,7 +1,6 @@
-import { getServerSession } from "next-auth";
 import { notFound } from "next/navigation";
+import { auth } from "@/auth";
 import FeedbackAdminView from "@/components/feedback/feedback-admin-view";
-import { authOptions } from "@/lib/auth";
 import { getFeedbackIdentityFromSession } from "@/lib/feedbackAccess";
 import { FEEDBACK_ISSUE_OPTIONS, isFeedbackAdminEnabled, isMessageFeedbackEnabled } from "@/lib/feedbackConfig";
 import { getFeedbackStorageInfo } from "@/lib/feedbackStore";
@@ -11,7 +10,7 @@ export default async function FeedbackAdminPage() {
     notFound();
   }
 
-  const session = await getServerSession(authOptions);
+  const session = await auth();
   const identity = getFeedbackIdentityFromSession(session);
 
   if (!identity.isAdmin) {

--- a/src/app/api/admin/feedback/[id]/route.ts
+++ b/src/app/api/admin/feedback/[id]/route.ts
@@ -1,6 +1,6 @@
-import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
-import { getFeedbackIdentityFromToken } from "@/lib/feedbackAccess";
+import { auth } from "@/auth";
+import { getFeedbackIdentityFromSession } from "@/lib/feedbackAccess";
 import { getAdminFeedbackById } from "@/lib/feedbackStore";
 import { isFeedbackAdminEnabled, isMessageFeedbackEnabled } from "@/lib/feedbackConfig";
 
@@ -16,12 +16,12 @@ export async function GET(req: NextRequest, { params }: Params) {
     return new NextResponse("Not found", { status: 404 });
   }
 
-  const token = await getToken({ req });
-  if (!token) {
+  const session = await auth();
+  if (!session) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const identity = getFeedbackIdentityFromToken(token);
+  const identity = getFeedbackIdentityFromSession(session);
   if (!identity.isAdmin) {
     return new NextResponse("Forbidden", { status: 403 });
   }

--- a/src/app/api/admin/feedback/route.ts
+++ b/src/app/api/admin/feedback/route.ts
@@ -1,6 +1,6 @@
-import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
-import { getFeedbackIdentityFromToken } from "@/lib/feedbackAccess";
+import { auth } from "@/auth";
+import { getFeedbackIdentityFromSession } from "@/lib/feedbackAccess";
 import {
   clampFeedbackQueryLimit,
   FEEDBACK_ISSUE_OPTIONS,
@@ -17,12 +17,12 @@ export async function GET(req: NextRequest) {
     return new NextResponse("Not found", { status: 404 });
   }
 
-  const token = await getToken({ req });
-  if (!token) {
+  const session = await auth();
+  if (!session) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const identity = getFeedbackIdentityFromToken(token);
+  const identity = getFeedbackIdentityFromSession(session);
   if (!identity.isAdmin) {
     return new NextResponse("Forbidden", { status: 403 });
   }

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,3 @@
-import NextAuth from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { handlers } from "@/auth";
 
-const handler = NextAuth(authOptions);
-
-export { handler as GET, handler as POST };
+export const { GET, POST } = handlers;

--- a/src/app/api/cva/threads/[id]/messages/route.ts
+++ b/src/app/api/cva/threads/[id]/messages/route.ts
@@ -1,5 +1,5 @@
-import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { getCvaBaseUrl } from "@/lib/cvaConfig";
 
 export const runtime = "nodejs";
@@ -25,9 +25,9 @@ async function forwardResponse(res: Response) {
 }
 
 export async function GET(req: NextRequest, { params }: Params) {
-  const token = await getToken({ req });
+  const session = await auth();
 
-  if (!token?.accessToken) {
+  if (!session?.accessToken) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
@@ -39,7 +39,7 @@ try {
   const res = await fetch(upstreamUrl, {
     method: "GET",
     headers: {
-      Authorization: `Bearer ${String(token.accessToken)}`,
+      Authorization: `Bearer ${String(session.accessToken)}`,
     },
     cache: "no-store",
   });
@@ -62,9 +62,9 @@ try {
 
 
 export async function POST(req: NextRequest, { params }: Params) {
-  const token = await getToken({ req });
+  const session = await auth();
 
-  if (!token?.accessToken) {
+  if (!session?.accessToken) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
@@ -83,7 +83,7 @@ try {
   const res = await fetch(`${baseUrl}/threads/${encodeURIComponent(id)}/messages`, {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${String(token.accessToken)}`,
+      Authorization: `Bearer ${String(session.accessToken)}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify(payload),

--- a/src/app/api/cva/threads/route.ts
+++ b/src/app/api/cva/threads/route.ts
@@ -1,5 +1,5 @@
-import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { getCvaBaseUrl } from "@/lib/cvaConfig";
 
 export const runtime = "nodejs";
@@ -36,9 +36,9 @@ async function forwardResponse(res: Response) {
 }
 
 export async function GET(req: NextRequest) {
-  const token = await getToken({ req });
+  const session = await auth();
 
-  if (!token?.accessToken) {
+  if (!session?.accessToken) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
@@ -49,7 +49,7 @@ export async function GET(req: NextRequest) {
     const res = await fetch(upstreamUrl, {
       method: "GET",
       headers: {
-        Authorization: `Bearer ${String(token.accessToken)}`,
+        Authorization: `Bearer ${String(session.accessToken)}`,
       },
       cache: "no-store",
     });
@@ -71,15 +71,15 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const token = await getToken({ req });
+  const session = await auth();
 
-  if (!token?.accessToken) {
+  if (!session?.accessToken) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
   const body = await req.json();
-  const subjectFromAccessToken = getSubjectFromAccessToken(String(token.accessToken));
-  const subject = subjectFromAccessToken ?? (typeof token.sub === "string" ? token.sub : null);
+  const subjectFromAccessToken = getSubjectFromAccessToken(String(session.accessToken));
+  const subject = subjectFromAccessToken ?? session.user?.id ?? null;
 
   const payload =
     body && typeof body === "object"
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
     const res = await fetch(`${baseUrl}/threads`, {
       method: "POST",
       headers: {
-        Authorization: `Bearer ${String(token.accessToken)}`,
+        Authorization: `Bearer ${String(session.accessToken)}`,
         "Content-Type": "application/json",
       },
       body: JSON.stringify(payload),

--- a/src/app/api/feedback/config/route.ts
+++ b/src/app/api/feedback/config/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getToken } from "next-auth/jwt";
+import { auth } from "@/auth";
 import {
   FEEDBACK_ISSUE_OPTIONS,
   getFeedbackCommentMaxLength,
@@ -8,17 +8,17 @@ import {
   isMessageFeedbackEnabled,
   shouldCaptureFeedbackConversationContext,
 } from "@/lib/feedbackConfig";
-import { getFeedbackIdentityFromToken } from "@/lib/feedbackAccess";
+import { getFeedbackIdentityFromSession } from "@/lib/feedbackAccess";
 import { getFeedbackStorageInfo } from "@/lib/feedbackStore";
 
-export async function GET(req: Request) {
-  const token = await getToken({ req: req as Parameters<typeof getToken>[0]["req"] });
+export async function GET() {
+  const session = await auth();
   const storage = getFeedbackStorageInfo();
 
   return NextResponse.json({
     enabled: isMessageFeedbackEnabled(),
     adminEnabled: isFeedbackAdminEnabled(),
-    canViewAdmin: token ? getFeedbackIdentityFromToken(token).isAdmin : false,
+    canViewAdmin: session ? getFeedbackIdentityFromSession(session).isAdmin : false,
     captureConversationContext: shouldCaptureFeedbackConversationContext(),
     commentMaxLength: getFeedbackCommentMaxLength(),
     disclosure: getFeedbackDisclosureText(),

--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,8 +1,8 @@
-import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 import { headers as nextHeaders } from "next/headers";
 import { getThreadForUser } from "@/lib/threadRegistryStore";
-import { createFeedbackReporterKey, getFeedbackIdentityFromToken, getFeedbackReporterAliases } from "@/lib/feedbackAccess";
+import { auth } from "@/auth";
+import { createFeedbackReporterKey, getFeedbackIdentityFromSession, getFeedbackReporterAliases } from "@/lib/feedbackAccess";
 import {
   getFeedbackCommentMaxLength,
   getFeedbackDisclosureText,
@@ -34,12 +34,12 @@ export async function POST(req: NextRequest) {
     return new NextResponse("Not found", { status: 404 });
   }
 
-  const token = await getToken({ req });
-  if (!token) {
+  const session = await auth();
+  if (!session) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const identity = getFeedbackIdentityFromToken(token);
+  const identity = getFeedbackIdentityFromSession(session);
   if (!identity.userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }

--- a/src/app/api/rasa/history/route.ts
+++ b/src/app/api/rasa/history/route.ts
@@ -1,6 +1,6 @@
-import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
 import { cookies, headers } from "next/headers";
+import { auth } from "@/auth";
 import { getFeedbackReporterAliases } from "@/lib/feedbackAccess";
 import { isMessageFeedbackEnabled } from "@/lib/feedbackConfig";
 import { listFeedbackStatusesForUserThread } from "@/lib/feedbackStore";
@@ -26,8 +26,8 @@ function parseThreadId(raw: string | null): number | null {
 export async function GET(req: NextRequest) {
   const cookieStore = await cookies();
   const headerStore = await headers();
-  const token = await getToken({ req });
-  const userSub = token?.sub ? String(token.sub) : null;
+  const session = await auth();
+  const userSub = session?.user?.id ? String(session.user.id) : null;
 
   if (!userSub) {
     return new NextResponse("Unauthorized", { status: 401 });

--- a/src/app/api/rasa/route.ts
+++ b/src/app/api/rasa/route.ts
@@ -1,5 +1,5 @@
-import { getToken } from "next-auth/jwt";
 import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { getRasaUrlForRequest, withRasaAuth } from "@/lib/rasaConfig";
 import { putUserAccessToken } from "@/lib/userTokenVault";
 import { buildRasaSenderId } from "@/lib/rasaSender";
@@ -53,16 +53,16 @@ export async function POST(req: NextRequest) {
   const traceId = readTraceId(req.headers);
 
   try {
-    const token = await getToken({ req });
+    const session = await auth();
 
-    if (!token?.accessToken || !token?.sub) {
+    if (!session?.accessToken || !session.user?.id) {
       return new NextResponse("Unauthorized", {
         status: 401,
         headers: withTraceIdHeaders(undefined, traceId),
       });
     }
 
-    const userSub = String(token.sub);
+    const userSub = String(session.user.id);
     const body = await req.json();
     const message = typeof body?.message === "string" ? body.message : "";
     const rawThreadId = body?.threadId;
@@ -82,9 +82,9 @@ export async function POST(req: NextRequest) {
     }
 
     const tokenPayload = {
-      accessToken: String(token.accessToken),
+      accessToken: String(session.accessToken),
       accessTokenExpiresAt:
-        typeof token.accessTokenExpires === "number" ? token.accessTokenExpires : undefined,
+        typeof session.accessTokenExpires === "number" ? session.accessTokenExpires : undefined,
     };
 
     putUserAccessToken({

--- a/src/app/api/rasa/stream/route.ts
+++ b/src/app/api/rasa/stream/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getToken } from "next-auth/jwt";
+import { auth } from "@/auth";
 import { addSubscriberForSender } from "@/lib/sseBus";
 import { putUserAccessToken } from "@/lib/userTokenVault";
 import { buildRasaSenderId } from "@/lib/rasaSender";
@@ -8,22 +8,22 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
-  const token = await getToken({ req });
+  const session = await auth();
 
-  if (!token?.accessToken || !token?.sub) {
+  if (!session?.accessToken || !session.user?.id) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const userSub = String(token.sub);
+  const userSub = String(session.user.id);
   const threadParam = req.nextUrl.searchParams.get("threadId");
   const parsedThreadId = threadParam ? Number(threadParam) : NaN;
   const threadId = Number.isFinite(parsedThreadId) ? parsedThreadId : null;
   const senderId = buildRasaSenderId(userSub, threadId);
 
   const tokenPayload = {
-    accessToken: String(token.accessToken),
+    accessToken: String(session.accessToken),
     accessTokenExpiresAt:
-      typeof token.accessTokenExpires === "number" ? token.accessTokenExpires : undefined,
+      typeof session.accessTokenExpires === "number" ? session.accessTokenExpires : undefined,
   };
 
   putUserAccessToken({

--- a/src/app/api/threads/[id]/route.ts
+++ b/src/app/api/threads/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getToken } from "next-auth/jwt";
 import { cookies, headers } from "next/headers";
+import { auth } from "@/auth";
 import { getRasaUrlForRequest, withRasaAuth } from "@/lib/rasaConfig";
 import { buildRasaSenderId } from "@/lib/rasaSender";
 import { deleteThreadForUser, getThreadForUser, renameThreadForUser } from "@/lib/threadRegistryStore";
@@ -19,8 +19,8 @@ function parseThreadId(raw: string): number | null {
 }
 
 export async function PATCH(req: NextRequest, { params }: Params) {
-  const token = await getToken({ req });
-  const userId = token?.sub ? String(token.sub) : null;
+  const session = await auth();
+  const userId = session?.user?.id ? String(session.user.id) : null;
   if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
@@ -50,8 +50,8 @@ export async function PATCH(req: NextRequest, { params }: Params) {
 }
 
 export async function DELETE(req: NextRequest, { params }: Params) {
-  const token = await getToken({ req });
-  const userId = token?.sub ? String(token.sub) : null;
+  const session = await auth();
+  const userId = session?.user?.id ? String(session.user.id) : null;
   if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }

--- a/src/app/api/threads/route.ts
+++ b/src/app/api/threads/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getToken } from "next-auth/jwt";
+import { auth } from "@/auth";
 import { createThreadForUser, listThreadsForUser } from "@/lib/threadRegistryStore";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export async function GET(req: NextRequest) {
-  const token = await getToken({ req });
-  const userId = token?.sub ? String(token.sub) : null;
+export async function GET() {
+  const session = await auth();
+  const userId = session?.user?.id ? String(session.user.id) : null;
   if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
@@ -17,8 +17,8 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const token = await getToken({ req });
-  const userId = token?.sub ? String(token.sub) : null;
+  const session = await auth();
+  const userId = session?.user?.id ? String(session.user.id) : null;
   if (!userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,0 +1,18 @@
+import type { NextAuthConfig } from "next-auth";
+import KeycloakProvider from "next-auth/providers/keycloak";
+
+export const keycloakIssuer = process.env.KEYCLOAK_ISSUER?.replace(/\/+$/, "") ?? "";
+
+export const authBaseConfig = {
+  providers: [
+    KeycloakProvider({
+      clientId: process.env.KEYCLOAK_CLIENT_ID!,
+      clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
+      issuer: keycloakIssuer,
+    }),
+  ],
+  session: {
+    strategy: "jwt",
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+} satisfies NextAuthConfig;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,5 @@
+import NextAuth from "next-auth";
+
+import { authConfig } from "@/lib/auth";
+
+export const { handlers, auth, signIn, signOut } = NextAuth(authConfig);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
-import KeycloakProvider from "next-auth/providers/keycloak";
-import type { AuthOptions, DefaultSession } from "next-auth";
+import type { DefaultSession, NextAuthConfig } from "next-auth";
+import type {} from "next-auth/jwt";
+import { authBaseConfig, keycloakIssuer } from "@/auth.config";
 import { isFeedbackAdmin } from "@/lib/feedbackAccess";
 
 const parsedRefreshSafetyMs = Number(process.env.NEXTAUTH_ACCESS_TOKEN_REFRESH_SAFETY_MS ?? "90000");
@@ -33,18 +34,8 @@ declare module "next-auth/jwt" {
   }
 }
 
-export const authOptions: AuthOptions = {
-  providers: [
-    KeycloakProvider({
-      clientId: process.env.KEYCLOAK_CLIENT_ID!,
-      clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
-      issuer: process.env.KEYCLOAK_ISSUER!,
-    }),
-  ],
-  session: {
-    strategy: "jwt",
-  },
-  secret: process.env.NEXTAUTH_SECRET,
+export const authConfig = {
+  ...authBaseConfig,
   callbacks: {
     async jwt({ token, account }) {
       if (account) {
@@ -80,7 +71,7 @@ export const authOptions: AuthOptions = {
       ) {
         if (token.refreshToken) {
           try {
-            const url = `${process.env.KEYCLOAK_ISSUER}/protocol/openid-connect/token`;
+            const url = `${keycloakIssuer}/protocol/openid-connect/token`;
             const params = new URLSearchParams({
               client_id: process.env.KEYCLOAK_CLIENT_ID!,
               client_secret: process.env.KEYCLOAK_CLIENT_SECRET!,
@@ -122,6 +113,7 @@ export const authOptions: AuthOptions = {
       return token;
     },
     async session({ session, token }) {
+      const sessionUserId = typeof token.sub === "string" ? token.sub : session.user?.id;
       session.accessToken = typeof token.accessToken === "string" ? token.accessToken : undefined;
       session.refreshToken = typeof token.refreshToken === "string" ? token.refreshToken : undefined;
       session.accessTokenExpires = typeof token.accessTokenExpires === "number" ? token.accessTokenExpires : undefined;
@@ -130,7 +122,7 @@ export const authOptions: AuthOptions = {
       session.isFeedbackAdmin = token.isFeedbackAdmin === true;
       session.user = {
         ...session.user,
-        id: typeof token.sub === "string" ? token.sub : undefined,
+        ...(sessionUserId ? { id: sessionUserId } : {}),
         email: typeof token.email === "string" ? token.email : session.user?.email ?? undefined,
         name: typeof token.name === "string" ? token.name : session.user?.name ?? undefined,
       };
@@ -138,4 +130,4 @@ export const authOptions: AuthOptions = {
       return session;
     },
   },
-};
+} satisfies NextAuthConfig;

--- a/src/lib/feedbackAccess.ts
+++ b/src/lib/feedbackAccess.ts
@@ -1,6 +1,5 @@
 import { createHash } from "crypto";
 import type { Session } from "next-auth";
-import type { JWT } from "next-auth/jwt";
 import { getFeedbackAdminEmails, getFeedbackAdminRoles } from "@/lib/feedbackConfig";
 
 function decodeJwtPayload(rawToken: string | null | undefined): Record<string, unknown> | null {
@@ -145,21 +144,6 @@ export function isFeedbackAdmin(params: {
 
   const tokenRoles = getAccessTokenRoles(params.accessToken);
   return tokenRoles.some((role) => adminRoles.includes(role));
-}
-
-export function getFeedbackIdentityFromToken(token: JWT) {
-  const fallbackEmail = getAccessTokenEmail(typeof token.accessToken === "string" ? token.accessToken : null);
-  const fallbackName = getAccessTokenName(typeof token.accessToken === "string" ? token.accessToken : null);
-
-  return {
-    userId: typeof token.sub === "string" ? token.sub : null,
-    userEmail: typeof token.email === "string" ? token.email : fallbackEmail,
-    userName: typeof token.name === "string" ? token.name : fallbackName,
-    isAdmin: isFeedbackAdmin({
-      email: typeof token.email === "string" ? token.email : fallbackEmail,
-      accessToken: typeof token.accessToken === "string" ? token.accessToken : null,
-    }),
-  };
 }
 
 export function getFeedbackIdentityFromSession(session: Session | null | undefined) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,31 +1,48 @@
-import { withAuth } from "next-auth/middleware";
+import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { SUPPORTED_LANGUAGES, DEFAULT_LANGUAGE } from "@/locales/config";
 
-export default withAuth(
-  async function middleware(req) {
-    const res = NextResponse.next();
-  const hasLang = req.cookies.get('lang');
-    if (!hasLang) {
-      const accept = req.headers.get('accept-language') || '';
-  const supported = SUPPORTED_LANGUAGES as readonly string[];
-      const preferred = accept
-        .split(',')
-        .map(p => p.trim().split(';')[0])
-        .map(code => code.split('-')[0])
-        .find(code => supported.includes(code));
-  const lang = (preferred as typeof SUPPORTED_LANGUAGES[number]) || DEFAULT_LANGUAGE;
-      res.cookies.set('lang', lang, { path: '/', maxAge: 60 * 60 * 24 * 365, sameSite: 'lax' });
-    }
+const SESSION_COOKIE_NAMES = [
+  "authjs.session-token",
+  "__Secure-authjs.session-token",
+  "next-auth.session-token",
+  "__Secure-next-auth.session-token",
+] as const;
 
+function ensureLanguageCookie(req: NextRequest, res: NextResponse) {
+  const hasLang = req.cookies.get("lang");
+  if (hasLang) {
     return res;
-  },
-  {
-    pages: {
-      signIn: "/api/auth/signin/keycloak",
-    },
   }
-);
+
+  const accept = req.headers.get("accept-language") || "";
+  const supported = SUPPORTED_LANGUAGES as readonly string[];
+  const preferred = accept
+    .split(",")
+    .map((part) => part.trim().split(";")[0])
+    .map((code) => code.split("-")[0])
+    .find((code) => supported.includes(code));
+  const lang = (preferred as typeof SUPPORTED_LANGUAGES[number]) || DEFAULT_LANGUAGE;
+
+  res.cookies.set("lang", lang, {
+    path: "/",
+    maxAge: 60 * 60 * 24 * 365,
+    sameSite: "lax",
+  });
+  return res;
+}
+
+export default function middleware(req: NextRequest) {
+  const hasSessionCookie = SESSION_COOKIE_NAMES.some((name) => req.cookies.has(name));
+
+  if (!hasSessionCookie) {
+    const signInUrl = new URL("/api/auth/signin", req.nextUrl.origin);
+    signInUrl.searchParams.set("callbackUrl", `${req.nextUrl.pathname}${req.nextUrl.search}`);
+    return ensureLanguageCookie(req, NextResponse.redirect(signInUrl));
+  }
+
+  return ensureLanguageCookie(req, NextResponse.next());
+}
 
 export const config = {
   matcher: ["/", "/admin/:path*"],


### PR DESCRIPTION
## Summary
- migrate the Webapp auth flow to next-auth v5 style APIs
- add shared auth entrypoints via `src/auth.ts` and `src/auth.config.ts`
- move server auth usage from `getServerSession`/`getToken` to `auth()`
- update middleware to use an edge-safe session-cookie gate and redirect through the built-in Auth.js sign-in page
- normalize the Keycloak issuer URL to avoid configuration mismatches
- add the required ESLint React plugins to support clean installs

## Validation
- clean containerized `pnpm install --force && pnpm build`
- local stack startup via docker compose
- live auth smoke test: sign-in page renders and POST to Keycloak sign-in redirects to the Keycloak authorization endpoint