### PR TITLE
Tighten Webapp CSP and replace the built-in sign-in page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,16 @@
 
 import type { NextConfig } from "next";
 
-const contentSecurityPolicyReportOnly = [
+const keycloakIssuer = process.env.KEYCLOAK_ISSUER?.replace(/\/+$/, "") ?? "";
+const keycloakOrigin = keycloakIssuer ? new URL(keycloakIssuer).origin : "";
+
+const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'self'",
   "font-src 'self' data:",
-  "form-action 'self'",
+  `form-action 'self'${keycloakOrigin ? ` ${keycloakOrigin}` : ""}`,
   "frame-ancestors 'none'",
-  "img-src 'self' data: blob:",
+  "img-src 'self' data: blob: https://authjs.dev",
   "object-src 'none'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
@@ -16,7 +19,7 @@ const contentSecurityPolicyReportOnly = [
 ].join("; ");
 
 const securityHeaders = [
-  { key: "Content-Security-Policy-Report-Only", value: contentSecurityPolicyReportOnly },
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
   { key: "Permissions-Policy", value: "camera=(), geolocation=(), microphone=()" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   { key: "X-Content-Type-Options", value: "nosniff" },

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,7 +11,7 @@ const contentSecurityPolicy = [
   "object-src 'none'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
-  "connect-src 'self' https: http: ws: wss:",
+  "connect-src 'self' ws: wss:",
   "upgrade-insecure-requests",
 ].join("; ");
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,17 +1,19 @@
 
 import type { NextConfig } from "next";
 
+const isDevelopment = process.env.NODE_ENV === "development";
+
 const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'self'",
-  "font-src 'self' data:",
+  "font-src 'self'",
   "form-action 'self'",
   "frame-ancestors 'none'",
-  "img-src 'self' data:",
+  "img-src 'self'",
   "object-src 'none'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",
-  "connect-src 'self' ws: wss:",
+  isDevelopment ? "connect-src 'self' ws: wss:" : "connect-src 'self'",
   "upgrade-insecure-requests",
 ].join("; ");
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,16 +1,13 @@
 
 import type { NextConfig } from "next";
 
-const keycloakIssuer = process.env.KEYCLOAK_ISSUER?.replace(/\/+$/, "") ?? "";
-const keycloakOrigin = keycloakIssuer ? new URL(keycloakIssuer).origin : "";
-
 const contentSecurityPolicy = [
   "default-src 'self'",
   "base-uri 'self'",
   "font-src 'self' data:",
-  `form-action 'self'${keycloakOrigin ? ` ${keycloakOrigin}` : ""}`,
+  "form-action 'self'",
   "frame-ancestors 'none'",
-  "img-src 'self' data: blob: https://authjs.dev",
+  "img-src 'self' data: blob:",
   "object-src 'none'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,7 @@ const contentSecurityPolicy = [
   "font-src 'self' data:",
   "form-action 'self'",
   "frame-ancestors 'none'",
-  "img-src 'self' data: blob:",
+  "img-src 'self' data:",
   "object-src 'none'",
   "script-src 'self' 'unsafe-inline'",
   "style-src 'self' 'unsafe-inline'",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,11 +30,6 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <title>{titleText}</title>
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(() => { try { var m = document.cookie.match(/(?:^|; )dark=([^;]+)/); var d = m ? decodeURIComponent(m[1]) === 'true' : false; var t = (document.cookie.match(/(?:^|; )theme=([^;]+)/) || [])[1]; if (d) document.documentElement.classList.add('dark'); else document.documentElement.classList.remove('dark'); if (t && decodeURIComponent(t) !== 'default') document.documentElement.setAttribute('data-theme', decodeURIComponent(t)); } catch (e) {} })();`,
-          }}
-        />
       </head>
       <body className="h-screen flex flex-col overflow-hidden">
         <SessionRoot>

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { signIn, useSession } from "next-auth/react";
+import { Button } from "@/components/ui/button";
+
+function resolveCallbackUrl(rawCallbackUrl: string | null): string {
+  if (!rawCallbackUrl) {
+    return "/";
+  }
+
+  return rawCallbackUrl.startsWith("/") ? rawCallbackUrl : "/";
+}
+
+export default function SignInPage() {
+  const { status } = useSession();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirectStartedRef = useRef(false);
+
+  const callbackUrl = useMemo(
+    () => resolveCallbackUrl(searchParams.get("callbackUrl")),
+    [searchParams]
+  );
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      router.replace(callbackUrl);
+      return;
+    }
+
+    if (status !== "unauthenticated" || redirectStartedRef.current) {
+      return;
+    }
+
+    redirectStartedRef.current = true;
+    void signIn("keycloak", { callbackUrl });
+  }, [callbackUrl, router, status]);
+
+  return (
+    <div className="flex h-full min-h-[calc(100vh-4rem)] items-center justify-center px-6 py-10">
+      <div className="w-full max-w-md rounded-2xl border bg-background p-8 text-center shadow-sm">
+        <h1 className="text-2xl font-semibold tracking-tight">Redirecting to sign in</h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          You will be sent to Keycloak to continue authentication.
+        </p>
+        <Button
+          className="mt-6 w-full"
+          onClick={() => {
+            redirectStartedRef.current = true;
+            void signIn("keycloak", { callbackUrl });
+          }}
+        >
+          Continue to sign in
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -15,4 +15,7 @@ export const authBaseConfig = {
     strategy: "jwt",
   },
   secret: process.env.NEXTAUTH_SECRET,
+  pages: {
+    signIn: "/signin",
+  },
 } satisfies NextAuthConfig;

--- a/src/components/SessionRoot.tsx
+++ b/src/components/SessionRoot.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { SessionProvider, useSession, signIn } from "next-auth/react";
+import { usePathname } from "next/navigation";
 import React, { useEffect } from "react";
 import { toast } from "sonner";
 
@@ -7,13 +8,18 @@ const SHOW_DEV_AUTH_TOASTS = process.env.NODE_ENV === "development";
 
 function SessionWatcher() {
   const { data: session, status } = useSession();
+  const pathname = usePathname();
   const lastRefreshRef = React.useRef<number | null>(null);
 
   useEffect(() => {
+    if (pathname === "/signin") {
+      return;
+    }
+
     if (status === "unauthenticated" || session?.error === "RefreshAccessTokenError") {
       signIn("keycloak", { callbackUrl: window.location.href });
     }
-  }, [session?.error, status]);
+  }, [pathname, session?.error, status]);
 
   useEffect(() => {
     if (!SHOW_DEV_AUTH_TOASTS) return;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -36,7 +36,7 @@ export default function middleware(req: NextRequest) {
   const hasSessionCookie = SESSION_COOKIE_NAMES.some((name) => req.cookies.has(name));
 
   if (!hasSessionCookie) {
-    const signInUrl = new URL("/api/auth/signin", req.nextUrl.origin);
+    const signInUrl = new URL("/signin", req.nextUrl.origin);
     signInUrl.searchParams.set("callbackUrl", `${req.nextUrl.pathname}${req.nextUrl.search}`);
     return ensureLanguageCookie(req, NextResponse.redirect(signInUrl));
   }


### PR DESCRIPTION
## Summary
- enforce Webapp CSP headers and tighten the remaining asset and connect source directives
- replace the built-in Auth.js provider selection screen with a custom `/signin` page for the single Keycloak provider
- remove the app-owned inline theme bootstrap script because the layout already applies theme cookies server-side

## Validation
- isolated Node 22 production build from a temporary container copy
- `GET /api/auth/providers` returns `200`
- unauthenticated `GET /` redirects to `/signin?callbackUrl=%2F`
- `POST /api/auth/signin/keycloak` with a fresh CSRF cookie returns `302` to Keycloak