### PR TITLE
Feat/webapp auth redirects

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm
+FROM mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm@sha256:7c2e711a4f7b02f32d2da16192d5e05aa7c95279be4ce889cff5df316f251c1d
 
 RUN corepack enable && corepack prepare pnpm@10.10.0 --activate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG WEBAPP_COMMIT_SHA=""
 ARG WEBAPP_IMAGE_TAG=""
 ARG WEBAPP_BUILD_DATE=""
 
-RUN mkdir -p /app/.data && chown -R node:node /app
+RUN mkdir -p /app/.data && chown -R node:node /app && chmod 700 /app/.data
 
 COPY --from=builder --chown=node:node /app/.next/standalone ./
 COPY --from=builder --chown=node:node /app/.next/static ./.next/static

--- a/README.md
+++ b/README.md
@@ -1,278 +1,72 @@
-# Webapp Service — Runbook
+# Webapp
 
-This README only covers:
+Run instructions for:
 
-- How to run the webapp as a developer
-- How to run it in production
+- Development using the Dev Container
+- Production using GitHub workflow-built images
 
----
+## Service Wiring
 
-## Related repositories
+- Webapp -> Rasa REST API (chat, history, tracker)
+- Webapp -> Action callback receiver (`/api/rasa/long-task-callback`)
+- Action -> Webapp secured proxy (`/api/rasa-proxy`)
+- Webapp -> external upstream APIs (GraphQL/analytics and CVA)
+- Webapp -> Keycloak for authentication
 
-- Webapp (this repo)
-- Action
-- Rasa
-- SSOT
+## Required Environment Variables
 
----
-
-## 1) Development setup
-
-### Prerequisites (recommended path)
-
-- Docker + Docker Compose
-- VS Code + Dev Containers extension
-
-### Dev Container workflow (recommended)
-
-1. Open this repository in VS Code.
-2. Choose **Reopen in Container**.
-3. Wait for post-create setup to finish (`corepack enable && corepack prepare pnpm@latest --activate && pnpm install --frozen-lockfile`).
-4. Configure `.env` (repo root) as shown below.
-5. Run the dev server.
-
-### Option B: Local machine
-
-Local-only prerequisites:
-
-- Node.js 22+
-- `pnpm` (or Corepack enabled)
-
-```bash
-corepack enable
-corepack prepare pnpm@latest --activate
-pnpm install --frozen-lockfile
-```
-
-### Configure environment (`.env` in repo root)
-
-Create/update:
-
-```env
-CALLBACK_BASE_URL="http://<local-webapp-host>:3000"
-RASA_URL_LIST="en=http://<local-rasa-host>:5005"
-RASA_AUTH_TOKEN="<shared-rasa-token>"
-
-KEYCLOAK_CLIENT_ID="<keycloak-client-id>"
-KEYCLOAK_CLIENT_SECRET="<keycloak-client-secret>"
-KEYCLOAK_ISSUER="https://<keycloak-host>/realms/<realm>"
-NEXTAUTH_SECRET="<random-long-secret>"
-
-ACTION_SERVER_TOKEN="<shared-action-token>"
-LONG_TASK_CALLBACK_TOKEN="<shared-callback-token>"
-RASA_PROXY_TIMEOUT_MS=120000
-RASA_PROXY_TARGETS='{"graphql":"https://<host>","analytics":"https://<host>"}'
-
-CVA_BASE_URL="https://<cva-api-host>/api/rest/cva/v1"
-
-MESSAGE_FEEDBACK_ENABLED="true"
-FEEDBACK_ADMIN_ENABLED="true"
-FEEDBACK_CAPTURE_CONTEXT_ENABLED="true"
-FEEDBACK_COMMENT_MAX_LENGTH="1000"
-FEEDBACK_ADMIN_EMAILS="admin@example.org"
-FEEDBACK_ADMIN_ROLES="cva-feedback-admin"
-FEEDBACK_REPORTER_SALT="<random-long-secret>"
-
-# Optional external Postgres for feedback storage.
-# If omitted, feedback falls back to a local file store for simple testing.
-# FEEDBACK_DATABASE_URL="postgresql://<user>:<password>@<postgres-host>:5432/<database>"
-# FEEDBACK_DB_HOST="<postgres-host>"
-# FEEDBACK_DB_PORT="5432"
-# FEEDBACK_DB_NAME="cva_feedback"
-# FEEDBACK_DB_USER="postgres"
-# FEEDBACK_DB_PASSWORD="postgres"
-# FEEDBACK_DB_SSL="false"
-# FEEDBACK_LOCAL_STORE_PATH="/app/.data/feedback-store.json"
-
-WEBAPP_VERSION="0.1.0"
-WEBAPP_COMMIT_SHA="<git-sha>"
-WEBAPP_IMAGE_TAG="webapp:local"
-
-RASA_VERSION_URL="http://<local-rasa-host>:5005/version"
-ACTION_VERSION_URL="http://<local-action-host>:5055/version"
-SSOT_VERSION_URL="http://<local-ssot-host>:7001/version"
-```
-
-`RASA_URL_LIST` supports separators `;`, `,`, or newline, for example `en=http://<rasa-en-host>:5005;el=http://<rasa-el-host>:5006`.
-If `MESSAGE_FEEDBACK_ENABLED="true"`, `FEEDBACK_REPORTER_SALT` is required.
-The Webapp now fails closed for feedback key generation instead of falling back
-to a built-in default salt.
-
-### Feedback storage
-
-The feedback feature is optional and env-gated.
-
-Storage modes:
-
-- No feedback DB env configured: feedback uses a local file store for simple testing
-- `FEEDBACK_DATABASE_URL` or `FEEDBACK_DB_*` configured: feedback uses PostgreSQL
-
-Examples:
-
-```env
-# Simple local fallback for testing
-MESSAGE_FEEDBACK_ENABLED="true"
-
-# External PostgreSQL for shared/dev/prod environments
-FEEDBACK_DATABASE_URL="postgresql://<user>:<password>@<postgres-host>:5432/<database>"
-```
-
-Notes:
-
-- The local fallback store is intended for development/testing only
-- In local dev, the default local file path is `.data/feedback-store.json`
-- In containers, the default local file path is `/app/.data/feedback-store.json`
-- For production or shared environments, configure PostgreSQL instead of relying on the local fallback
-- The PostgreSQL tables are created automatically on first use; no manual migration step is required for the feedback feature
-
-Recommended version endpoint convention for related services:
-
-- Use `GET /version`
-- Return JSON with at least `service`, `version`, `commitSha`, `imageTag`
-- For Rasa and Action, also include the SSOT version they currently use
-- For Action, include the active LLM model/runtime settings when possible
-
-The Webapp itself now exposes `GET /version`.
-
-### Run locally
-
-```bash
-pnpm dev
-```
-
-Open the local webapp URL you configured for development.
-
-### VS Code tasks (optional)
-
-This repo includes `.vscode/tasks.json` with:
-
-- `Start Webbapp in dev`
-
-Run from VS Code: **Terminal → Run Task**.
-
----
-
-## 2) Production run
-
-### Required dependencies
-
-- One or more Rasa containers reachable from the Webapp
-- Action service token shared with the Action container
-- Upstream GraphQL/analytics APIs reachable from Webapp proxy
-
-### Recommended image tags
-
-- `<container-registry>/webapp:latest`
-- `<container-registry>/action:latest`
-- `<container-registry>/rasa:<locale>-latest`
-
-### Required Webapp environment variables
-
-- `RASA_URL_LIST`
-- `RASA_AUTH_TOKEN`
-- `CALLBACK_BASE_URL`
-- `CVA_BASE_URL`
-- `RASA_PROXY_TARGETS`
+- `NEXTAUTH_SECRET`
+- `NEXTAUTH_URL`
 - `KEYCLOAK_CLIENT_ID`
 - `KEYCLOAK_CLIENT_SECRET`
 - `KEYCLOAK_ISSUER`
-- `NEXTAUTH_SECRET`
-- `NEXTAUTH_URL`
-- `HOSTNAME=0.0.0.0`
-- `ACTION_SERVER_TOKEN`
-- `LONG_TASK_CALLBACK_TOKEN`
-Optional feedback/admin variables:
+- `RASA_URL_LIST` (example: `en=http://rasa:5005`)
+- `RASA_AUTH_TOKEN`
+- `ACTION_SERVER_TOKEN` (must match Action)
+- `LONG_TASK_CALLBACK_TOKEN` (must match Action)
+- `RASA_PROXY_TARGETS` (must include `graphql`; usually also `analytics`)
+- `CVA_BASE_URL`
 
-- `MESSAGE_FEEDBACK_ENABLED`
-- `FEEDBACK_ADMIN_ENABLED`
-- `FEEDBACK_CAPTURE_CONTEXT_ENABLED`
-- `FEEDBACK_COMMENT_MAX_LENGTH`
-- `FEEDBACK_ADMIN_EMAILS`
-- `FEEDBACK_ADMIN_ROLES`
-- `FEEDBACK_REPORTER_SALT` (required when `MESSAGE_FEEDBACK_ENABLED=true`)
-- `FEEDBACK_DATABASE_URL`
-- `FEEDBACK_DB_HOST`
-- `FEEDBACK_DB_PORT`
-- `FEEDBACK_DB_NAME`
-- `FEEDBACK_DB_USER`
-- `FEEDBACK_DB_PASSWORD`
-- `FEEDBACK_DB_SSL`
-- `FEEDBACK_LOCAL_STORE_PATH`
-- `WEBAPP_VERSION`
-- `WEBAPP_COMMIT_SHA`
-- `WEBAPP_IMAGE_TAG`
-- `RASA_VERSION_URL`
-- `ACTION_VERSION_URL`
-- `SSOT_VERSION_URL`
+If feedback is enabled:
 
-### Minimal production compose snippet (webapp)
+- `MESSAGE_FEEDBACK_ENABLED=true`
+- `FEEDBACK_REPORTER_SALT` (required)
 
-Use this template and replace placeholders:
+## Development (Dev Container)
 
-```yaml
-services:
-  cva-webapp:
-    image: <container-registry>/webapp:latest
-    container_name: cva-webapp
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    environment:
-      RASA_URL_LIST: |
-        en=http://<rasa-en-service>:5005
-        cs=http://<rasa-cs-service>:5005
-        el=http://<rasa-el-service>:5005
-      RASA_AUTH_TOKEN: "<shared-rasa-token>"
-      CALLBACK_BASE_URL: "http://<webapp-service>:3000"
-      CVA_BASE_URL: "https://<cva-api-host>/api/rest/cva/v1"
-      RASA_PROXY_TARGETS: '{"graphql":"https://<graphql-host>","analytics":"https://<analytics-host>"}'
-      KEYCLOAK_CLIENT_ID: "<keycloak-client-id>"
-      KEYCLOAK_CLIENT_SECRET: "<keycloak-client-secret>"
-      KEYCLOAK_ISSUER: "https://<keycloak-host>/realms/<realm>"
-      NEXTAUTH_SECRET: "<random-long-secret>"
-      NEXTAUTH_URL: "https://<public-webapp-url>"
-      HOSTNAME: "0.0.0.0"
-      ACTION_SERVER_TOKEN: "<shared-action-token>"
-      LONG_TASK_CALLBACK_TOKEN: "<shared-callback-token>"
-      MESSAGE_FEEDBACK_ENABLED: "true"
-      FEEDBACK_ADMIN_ENABLED: "true"
-      FEEDBACK_REPORTER_SALT: "<random-long-secret>"
-      FEEDBACK_DATABASE_URL: "postgresql://postgres:postgres@feedback-db:5432/cva_feedback"
-```
-
-Start:
-
-```bash
-docker compose pull
-docker compose up -d
-```
-
----
-
-## 3) Quick verification
-
-- `docker compose ps`
-- `docker compose logs -f cva-webapp`
-- Confirm `RASA_URL_LIST` targets are reachable
-- Confirm `ACTION_SERVER_TOKEN` matches Webapp + Action for proxy requests
-- Confirm `LONG_TASK_CALLBACK_TOKEN` matches Webapp + Action for callback requests
-- Confirm `NEXTAUTH_URL` matches the public URL
-- Confirm `FEEDBACK_REPORTER_SALT` is set whenever feedback is enabled
-
----
-
-## 4) Common commands
-
-Run dev server:
+1. Open this repository in VS Code.
+2. Reopen in container.
+3. Start dev server:
 
 ```bash
 pnpm dev
 ```
 
-Inspect running stack:
+The dev container definition is in `.devcontainer/Dockerfile`.
+
+## Production (Workflow-built image)
+
+GitHub workflows build and publish Webapp images to GHCR.
+
+Typical tags:
+
+- `ghcr.io/<org>/webapp:latest`
+- `ghcr.io/<org>/webapp:<git-sha>`
+
+Run example:
 
 ```bash
-docker compose ps
-docker compose logs -f cva-webapp
+docker run --rm -p 3000:3000 \
+  -e NEXTAUTH_SECRET=<secret> \
+  -e NEXTAUTH_URL=https://<public-webapp-url> \
+  -e KEYCLOAK_CLIENT_ID=<id> \
+  -e KEYCLOAK_CLIENT_SECRET=<secret> \
+  -e KEYCLOAK_ISSUER=https://<issuer>/realms/<realm> \
+  -e RASA_URL_LIST=en=http://rasa:5005 \
+  -e RASA_AUTH_TOKEN=<shared-rasa-token> \
+  -e ACTION_SERVER_TOKEN=<shared-action-token> \
+  -e LONG_TASK_CALLBACK_TOKEN=<shared-callback-token> \
+  -e RASA_PROXY_TARGETS='{"graphql":"https://<host>","analytics":"https://<host>"}' \
+  -e CVA_BASE_URL=https://<host>/api/rest/cva/v1 \
+  ghcr.io/<org>/webapp:latest
 ```
-

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,6 +21,7 @@ const securityHeaders = [
   { key: "Content-Security-Policy", value: contentSecurityPolicy },
   { key: "Permissions-Policy", value: "camera=(), geolocation=(), microphone=()" },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Strict-Transport-Security", value: "max-age=31536000; includeSubDomains" },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },
 ];

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.6.0",
     "i18next": "^25.4.2",
-    "jose": "^6.0.11",
     "lucide-react": "^0.511.0",
     "next": "15.5.18",
     "next-auth": "5.0.0-beta.31",
@@ -33,7 +32,6 @@
     "zustand": "^5.0.5"
   },
   "devDependencies": {
-    "@next/eslint-plugin-next": "15.5.18",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^22",
@@ -42,8 +40,6 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.18",
-    "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.0",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "node server.js",
-    "lint": "next lint"
+    "lint": "eslint . --ignore-pattern .next --ignore-pattern next-env.d.ts"
   },
   "dependencies": {
     "@radix-ui/react-scroll-area": "^1.2.9",
@@ -20,7 +20,6 @@
     "lucide-react": "^0.511.0",
     "next": "15.5.18",
     "next-auth": "5.0.0-beta.31",
-    "next-i18next": "^15.4.2",
     "next-themes": "^0.4.6",
     "pg": "^8.20.0",
     "radix-ui": "^1.4.3",
@@ -34,9 +33,10 @@
     "zustand": "^5.0.5"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "15.5.18",
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/pg": "^8.20.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -52,9 +52,14 @@
     "overrides": {
       "i18next-fs-backend": "2.6.4",
       "lodash": "4.18.0",
+      "postcss": "8.5.10",
       "preact": "10.26.10",
       "react-is": "19.1.0"
     }
+  },
+  "engines": {
+    "node": ">=22.0.0",
+    "pnpm": ">=10.10.0"
   },
   "packageManager": "pnpm@10.10.0+sha512.d615db246fe70f25dcfea6d8d73dee782ce23e2245e3c4f6f888249fb568149318637dca73c2c5c8ef2a4ca0d5657fb9567188bfab47f566d1ee6ce987815c39"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,9 +36,6 @@ importers:
       i18next:
         specifier: ^25.4.2
         version: 25.4.2(typescript@5.8.3)
-      jose:
-        specifier: ^6.0.11
-        version: 6.0.11
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.1.0)
@@ -85,9 +82,6 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
-      '@next/eslint-plugin-next':
-        specifier: 15.5.18
-        version: 15.5.18
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.7
@@ -109,12 +103,6 @@ importers:
       eslint-config-next:
         specifier: 15.5.18
         version: 15.5.18(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)
-      eslint-plugin-react:
-        specifier: ^7.37.5
-        version: 7.37.5(eslint@9.27.0(jiti@2.4.2))
-      eslint-plugin-react-hooks:
-        specifier: ^5.2.0
-        version: 5.2.0(eslint@9.27.0(jiti@2.4.2))
       tailwindcss:
         specifier: ^4
         version: 4.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   i18next-fs-backend: 2.6.4
   lodash: 4.18.0
+  postcss: 8.5.10
   preact: 10.26.10
   react-is: 19.1.0
 
@@ -16,13 +17,13 @@ importers:
     dependencies:
       '@radix-ui/react-scroll-area':
         specifier: ^1.2.9
-        version: 1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.2.10(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-select':
         specifier: ^2.2.5
-        version: 2.2.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 2.2.6(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.2
-        version: 1.2.2(@types/react@19.1.4)(react@19.1.0)
+        version: 1.2.3(@types/react@19.1.4)(react@19.1.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -47,9 +48,6 @@ importers:
       next-auth:
         specifier: 5.0.0-beta.31
         version: 5.0.0-beta.31(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      next-i18next:
-        specifier: ^15.4.2
-        version: 15.4.2(@types/react@19.1.4)(i18next@25.4.2(typescript@5.8.3))(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-i18next@15.7.3(i18next@25.4.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -87,12 +85,15 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@next/eslint-plugin-next':
+        specifier: 15.5.18
+        version: 15.5.18
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.7
       '@types/node':
-        specifier: ^20
-        version: 20.17.48
+        specifier: ^22
+        version: 22.19.19
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -479,9 +480,6 @@ packages:
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
-  '@radix-ui/primitive@1.1.2':
-    resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
-
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
@@ -655,19 +653,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-dismissable-layer@1.1.10':
-    resolution: {integrity: sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
     peerDependencies:
@@ -692,15 +677,6 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-focus-guards@1.1.2':
-    resolution: {integrity: sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   '@radix-ui/react-focus-guards@1.1.3':
@@ -851,19 +827,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-popper@1.2.7':
-    resolution: {integrity: sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-popper@1.2.8':
     resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
     peerDependencies:
@@ -879,19 +842,6 @@ packages:
 
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-presence@1.1.4':
-    resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -981,32 +931,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-scroll-area@1.2.9':
-    resolution: {integrity: sha512-YSjEfBXnhUELsO2VzjdtYYD4CfQjvao+lhhrX5XsHD7/cyUNzljF1FHEbgTPN7LH2MClfwRMIsYlqTYpKTTe2A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-select@2.2.5':
-    resolution: {integrity: sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
@@ -1044,15 +968,6 @@ packages:
       '@types/react':
         optional: true
       '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-slot@1.2.2':
-    resolution: {integrity: sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
         optional: true
 
   '@radix-ui/react-slot@1.2.3':
@@ -1382,19 +1297,14 @@ packages:
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
-  '@types/hoist-non-react-statics@3.3.7':
-    resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
-    peerDependencies:
-      '@types/react': '*'
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/node@20.17.48':
-    resolution: {integrity: sha512-KpSfKOHPsiSC4IkZeu2LsusFwExAIVGkhG1KkbaBMLwau0uMhj0fCrvyg9ddM2sAvd+gtiBJLir4LAw1MNMIaw==}
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -1677,9 +1587,6 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
-
-  core-js@3.45.1:
-    resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2112,14 +2019,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hoist-non-react-statics@3.3.2:
-    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
-
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
-
-  i18next-fs-backend@2.6.4:
-    resolution: {integrity: sha512-lzbUnowXYd5RFO8flpQhd9khYWNgrzwtxHw1kktJCiTRBaAEiLB2t9EPSXRj8qlC7WcEgFDIsmBUixyludcznw==}
 
   i18next@25.4.2:
     resolution: {integrity: sha512-gD4T25a6ovNXsfXY1TwHXXXLnD/K2t99jyYMCSimSCBnBRJVQr5j+VAaU83RJCPzrTGhVQ6dqIga66xO2rtd5g==}
@@ -2461,15 +2362,6 @@ packages:
       nodemailer:
         optional: true
 
-  next-i18next@15.4.2:
-    resolution: {integrity: sha512-zgRxWf7kdXtM686ecGIBQL+Bq0+DqAhRlasRZ3vVF0TmrNTWkVhs52n//oU3Fj5O7r/xOKkECDUwfOuXVwTK/g==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      i18next: '>= 23.7.13'
-      next: '>= 12.0.0'
-      react: '>= 17.0.2'
-      react-i18next: '>= 13.5.0'
-
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
@@ -2612,12 +2504,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -2753,6 +2641,7 @@ packages:
   recharts@2.15.3:
     resolution: {integrity: sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -2939,6 +2828,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -2995,8 +2885,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unrs-resolver@1.7.2:
     resolution: {integrity: sha512-BBKpaylOW8KbHsu378Zky/dGh4ckT/4NW/0SHRABdqRLcQJ2dAOjDo9g97p04sWflm0kqPqpUatxReNV/dqI5A==}
@@ -3380,8 +3270,6 @@ snapshots:
 
   '@radix-ui/number@1.1.1': {}
 
-  '@radix-ui/primitive@1.1.2': {}
-
   '@radix-ui/primitive@1.1.3': {}
 
   '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
@@ -3553,19 +3441,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
 
-  '@radix-ui/react-dismissable-layer@1.1.10(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 19.1.4
-      '@types/react-dom': 19.1.5(@types/react@19.1.4)
-
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -3593,12 +3468,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
-
-  '@radix-ui/react-focus-guards@1.1.2(@types/react@19.1.4)(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.1.4
 
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
@@ -3789,24 +3658,6 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
-  '@radix-ui/react-popper@1.2.7(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/rect': 1.1.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 19.1.4
-      '@types/react-dom': 19.1.5(@types/react@19.1.4)
-
   '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@floating-ui/react-dom': 2.1.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3828,16 +3679,6 @@ snapshots:
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 19.1.4
-      '@types/react-dom': 19.1.5(@types/react@19.1.4)
-
-  '@radix-ui/react-presence@1.1.4(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.4)(react@19.1.0)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -3926,52 +3767,6 @@ snapshots:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
 
-  '@radix-ui/react-scroll-area@1.2.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 19.1.4
-      '@types/react-dom': 19.1.5(@types/react@19.1.4)
-
-  '@radix-ui/react-select@2.2.5(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.2
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-dismissable-layer': 1.1.10(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-popper': 1.2.7(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.4)(react@19.1.0)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      aria-hidden: 1.2.6
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-remove-scroll: 2.7.1(@types/react@19.1.4)(react@19.1.0)
-    optionalDependencies:
-      '@types/react': 19.1.4
-      '@types/react-dom': 19.1.5(@types/react@19.1.4)
-
   '@radix-ui/react-select@2.2.6(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/number': 1.1.1
@@ -4028,13 +3823,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.4
       '@types/react-dom': 19.1.5(@types/react@19.1.4)
-
-  '@radix-ui/react-slot@1.2.2(@types/react@19.1.4)(react@19.1.0)':
-    dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.4)(react@19.1.0)
-      react: 19.1.0
-    optionalDependencies:
-      '@types/react': 19.1.4
 
   '@radix-ui/react-slot@1.2.3(@types/react@19.1.4)(react@19.1.0)':
     dependencies:
@@ -4304,7 +4092,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.7
       '@tailwindcss/oxide': 4.1.7
-      postcss: 8.5.3
+      postcss: 8.5.10
       tailwindcss: 4.1.7
 
   '@tybys/wasm-util@0.9.0':
@@ -4338,22 +4126,17 @@ snapshots:
 
   '@types/estree@1.0.7': {}
 
-  '@types/hoist-non-react-statics@3.3.7(@types/react@19.1.4)':
-    dependencies:
-      '@types/react': 19.1.4
-      hoist-non-react-statics: 3.3.2
-
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
-  '@types/node@20.17.48':
+  '@types/node@22.19.19':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.21.0
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 20.17.48
+      '@types/node': 22.19.19
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
@@ -4655,8 +4438,6 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
-
-  core-js@3.45.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5230,15 +5011,9 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hoist-non-react-statics@3.3.2:
-    dependencies:
-      react-is: 19.1.0
-
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
-
-  i18next-fs-backend@2.6.4: {}
 
   i18next@25.4.2(typescript@5.8.3):
     dependencies:
@@ -5535,20 +5310,6 @@ snapshots:
       next: 15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
-  next-i18next@15.4.2(@types/react@19.1.4)(i18next@25.4.2(typescript@5.8.3))(next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-i18next@15.7.3(i18next@25.4.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3))(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.27.1
-      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.1.4)
-      core-js: 3.45.1
-      hoist-non-react-statics: 3.3.2
-      i18next: 25.4.2(typescript@5.8.3)
-      i18next-fs-backend: 2.6.4
-      next: 15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-i18next: 15.7.3(i18next@25.4.2(typescript@5.8.3))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@types/react'
-
   next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -5559,7 +5320,7 @@ snapshots:
       '@next/env': 15.5.18
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001718
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       styled-jsx: 5.1.6(react@19.1.0)
@@ -5697,13 +5458,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.3:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -6206,7 +5961,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@6.19.8: {}
+  undici-types@6.21.0: {}
 
   unrs-resolver@1.7.2:
     dependencies:

--- a/src/app/api/feedback/config/route.ts
+++ b/src/app/api/feedback/config/route.ts
@@ -13,12 +13,16 @@ import { getFeedbackStorageInfo } from "@/lib/feedbackStore";
 
 export async function GET() {
   const session = await auth();
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
   const storage = getFeedbackStorageInfo();
 
   return NextResponse.json({
     enabled: isMessageFeedbackEnabled(),
     adminEnabled: isFeedbackAdminEnabled(),
-    canViewAdmin: session ? getFeedbackIdentityFromSession(session).isAdmin : false,
+    canViewAdmin: getFeedbackIdentityFromSession(session).isAdmin,
     captureConversationContext: shouldCaptureFeedbackConversationContext(),
     commentMaxLength: getFeedbackCommentMaxLength(),
     disclosure: getFeedbackDisclosureText(),

--- a/src/app/api/rasa-proxy/route.ts
+++ b/src/app/api/rasa-proxy/route.ts
@@ -7,7 +7,7 @@ import {
   withTraceIdHeaders,
 } from "@/lib/traceId";
 
-const FETCH_TIMEOUT_MS = Number(process.env.RASA_PROXY_TIMEOUT_MS ?? 60000);
+const FETCH_TIMEOUT_MS = Number(process.env.RASA_PROXY_TIMEOUT_MS ?? 120000);
 const ACTION_SERVER_TOKEN = process.env.ACTION_SERVER_TOKEN;
 
 type ProxyRequestBody = {

--- a/src/app/api/rasa/bots/route.ts
+++ b/src/app/api/rasa/bots/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from "next/server";
+import { auth } from "@/auth";
 import { getRasaBots } from "@/lib/rasaConfig";
 
 export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
   const bots = getRasaBots();
   return NextResponse.json({ bots });
 }

--- a/src/app/api/runtime-health/route.ts
+++ b/src/app/api/runtime-health/route.ts
@@ -1,0 +1,548 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { getFeedbackIdentityFromSession } from "@/lib/feedbackAccess";
+import { getRasaBots, withRasaAuth } from "@/lib/rasaConfig";
+
+type HealthStatus = "up" | "degraded" | "down" | "misconfigured" | "unknown";
+
+type ServiceHealthItem = {
+  key: string;
+  label: string;
+  status: HealthStatus;
+  detail: string;
+  httpStatus?: number;
+  latencyMs?: number;
+  checkedAt: string;
+};
+
+type ConfigHealthItem = {
+  key: string;
+  status: "ok" | "warning" | "error";
+  detail: string;
+};
+
+type ExternalHealthItem = {
+  key: string;
+  label: string;
+  status: HealthStatus;
+  detail: string;
+  httpStatus?: number;
+  latencyMs?: number;
+  checkedAt: string;
+};
+
+type RuntimeHealthResponse = {
+  checkedAt: string;
+  overall: HealthStatus;
+  visibility: "full" | "limited";
+  services: ServiceHealthItem[];
+  config: ConfigHealthItem[];
+  external: ExternalHealthItem[];
+};
+
+function readEnv(name: string): string | null {
+  const value = process.env[name]?.trim();
+  return value ? value : null;
+}
+
+function parseProxyTargets(): Record<string, string> {
+  const raw = readEnv("RASA_PROXY_TARGETS");
+  if (!raw) return {};
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object") return {};
+
+    const targets: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof key === "string" && typeof value === "string" && value.trim()) {
+        targets[key.trim()] = value.trim();
+      }
+    }
+    return targets;
+  } catch {
+    return {};
+  }
+}
+
+function getWebappVersionUrl(): string {
+  const configured = readEnv("WEBAPP_VERSION_URL");
+  if (configured) return configured;
+  const port = readEnv("PORT") ?? "3000";
+  return `http://127.0.0.1:${port}/version`;
+}
+
+type RasaVersionTarget = {
+  key: string;
+  label: string;
+  url: string;
+};
+
+function getRasaVersionTargets(): RasaVersionTarget[] {
+  const configured = readEnv("RASA_VERSION_URL");
+  if (configured) {
+    return [
+      {
+        key: "rasa",
+        label: "Rasa",
+        url: withRasaAuth(configured),
+      },
+    ];
+  }
+
+  const bots = getRasaBots();
+  if (bots.length === 0) {
+    return [];
+  }
+
+  return bots.map((bot) => ({
+    key: `rasa:${bot.lang}`,
+    label: `Rasa (${bot.lang})`,
+    url: withRasaAuth(`${bot.url.replace(/\/$/, "")}/version`),
+  }));
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const normalizedBase = baseUrl.trim().replace(/\/$/, "");
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+function resolveGraphqlUrl(): string | null {
+  const targets = parseProxyTargets();
+  const base = targets.graphql;
+  if (!base) return null;
+  return joinUrl(base, "/api/graphql/aggregation");
+}
+
+function resolveAnalyticsUrl(): string | null {
+  const targets = parseProxyTargets();
+  const base = targets.analytics;
+  if (!base) return null;
+  return joinUrl(base, "/api/rest/analytics-center/countries?limit=1&offset=0");
+}
+
+function resolveCvaThreadsUrl(): string | null {
+  const base = readEnv("CVA_BASE_URL");
+  if (!base) return null;
+  return joinUrl(base, "/threads?limit=1");
+}
+
+function resolveKeycloakDiscoveryUrl(): string | null {
+  const issuer = readEnv("KEYCLOAK_ISSUER");
+  if (!issuer) return null;
+  return joinUrl(issuer, "/.well-known/openid-configuration");
+}
+
+function classifyHttpStatus(status: number): HealthStatus {
+  if (status === 401 || status === 403) return "misconfigured";
+  if (status >= 500) return "down";
+  if (status >= 400) return "degraded";
+  return "up";
+}
+
+async function probeVersionEndpoint(params: {
+  key: string;
+  label: string;
+  url: string | null;
+}): Promise<ServiceHealthItem> {
+  const checkedAt = new Date().toISOString();
+  if (!params.url) {
+    return {
+      key: params.key,
+      label: params.label,
+      status: "misconfigured",
+      detail: "Version URL is not configured",
+      checkedAt,
+    };
+  }
+
+  const started = Date.now();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 2000);
+
+  try {
+    const response = await fetch(params.url, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    const latencyMs = Date.now() - started;
+    const contentType = response.headers.get("content-type") ?? "";
+
+    if (!response.ok) {
+      const detail = response.status === 401 || response.status === 403
+        ? `Auth/config issue (${response.status})`
+        : `Endpoint returned ${response.status}`;
+      return {
+        key: params.key,
+        label: params.label,
+        status: response.status === 401 || response.status === 403 ? "misconfigured" : "down",
+        detail,
+        httpStatus: response.status,
+        latencyMs,
+        checkedAt,
+      };
+    }
+
+    if (!contentType.toLowerCase().includes("application/json")) {
+      return {
+        key: params.key,
+        label: params.label,
+        status: "degraded",
+        detail: "Version endpoint returned non-JSON payload",
+        httpStatus: response.status,
+        latencyMs,
+        checkedAt,
+      };
+    }
+
+    return {
+      key: params.key,
+      label: params.label,
+      status: latencyMs > 1500 ? "degraded" : "up",
+      detail: latencyMs > 1500 ? "Service reachable but slow" : "Service reachable",
+      httpStatus: response.status,
+      latencyMs,
+      checkedAt,
+    };
+  } catch (error) {
+    const latencyMs = Date.now() - started;
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      key: params.key,
+      label: params.label,
+      status: "down",
+      detail: `Probe failed: ${message}`,
+      latencyMs,
+      checkedAt,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function probeExternalGet(params: {
+  key: string;
+  label: string;
+  url: string | null;
+  accessToken?: string | null;
+}): Promise<ExternalHealthItem> {
+  const checkedAt = new Date().toISOString();
+  if (!params.url) {
+    return {
+      key: params.key,
+      label: params.label,
+      status: "misconfigured",
+      detail: "External endpoint URL is not configured",
+      checkedAt,
+    };
+  }
+
+  const started = Date.now();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 2500);
+
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+    };
+    if (params.accessToken) {
+      headers.Authorization = `Bearer ${params.accessToken}`;
+    }
+
+    const response = await fetch(params.url, {
+      method: "GET",
+      headers,
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    const latencyMs = Date.now() - started;
+    const status = classifyHttpStatus(response.status);
+
+    return {
+      key: params.key,
+      label: params.label,
+      status,
+      detail: status === "up" ? "Endpoint reachable" : `Endpoint returned ${response.status}`,
+      httpStatus: response.status,
+      latencyMs,
+      checkedAt,
+    };
+  } catch (error) {
+    const latencyMs = Date.now() - started;
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      key: params.key,
+      label: params.label,
+      status: "down",
+      detail: `Probe failed: ${message}`,
+      latencyMs,
+      checkedAt,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function probeExternalGraphql(params: {
+  key: string;
+  label: string;
+  url: string | null;
+  accessToken?: string | null;
+}): Promise<ExternalHealthItem> {
+  const checkedAt = new Date().toISOString();
+  if (!params.url) {
+    return {
+      key: params.key,
+      label: params.label,
+      status: "misconfigured",
+      detail: "GraphQL endpoint URL is not configured",
+      checkedAt,
+    };
+  }
+
+  const started = Date.now();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 2500);
+
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    };
+    if (params.accessToken) {
+      headers.Authorization = `Bearer ${params.accessToken}`;
+    }
+
+    const response = await fetch(params.url, {
+      method: "POST",
+      headers,
+      cache: "no-store",
+      signal: controller.signal,
+      body: JSON.stringify({ query: "query { __typename }" }),
+    });
+
+    const latencyMs = Date.now() - started;
+    const status = classifyHttpStatus(response.status);
+
+    if (!response.ok) {
+      return {
+        key: params.key,
+        label: params.label,
+        status,
+        detail: `GraphQL endpoint returned ${response.status}`,
+        httpStatus: response.status,
+        latencyMs,
+        checkedAt,
+      };
+    }
+
+    return {
+      key: params.key,
+      label: params.label,
+      status: latencyMs > 2000 ? "degraded" : "up",
+      detail: latencyMs > 2000 ? "GraphQL reachable but slow" : "GraphQL reachable",
+      httpStatus: response.status,
+      latencyMs,
+      checkedAt,
+    };
+  } catch (error) {
+    const latencyMs = Date.now() - started;
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return {
+      key: params.key,
+      label: params.label,
+      status: "down",
+      detail: `Probe failed: ${message}`,
+      latencyMs,
+      checkedAt,
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function collectConfigHealth(): ConfigHealthItem[] {
+  const items: ConfigHealthItem[] = [];
+  const proxyTargets = parseProxyTargets();
+
+  const rasaUrlList = readEnv("RASA_URL_LIST");
+  items.push({
+    key: "rasa_url_list",
+    status: rasaUrlList ? "ok" : "error",
+    detail: rasaUrlList ? "RASA_URL_LIST configured" : "RASA_URL_LIST missing",
+  });
+
+  const rasaToken = readEnv("RASA_AUTH_TOKEN");
+  items.push({
+    key: "rasa_auth_token",
+    status: rasaToken ? "ok" : "warning",
+    detail: rasaToken ? "RASA auth token configured" : "RASA auth token missing",
+  });
+
+  const actionToken = readEnv("ACTION_SERVER_TOKEN");
+  items.push({
+    key: "action_server_token",
+    status: actionToken ? "ok" : "error",
+    detail: actionToken ? "Action proxy token configured" : "ACTION_SERVER_TOKEN missing",
+  });
+
+  items.push({
+    key: "proxy_target_graphql",
+    status: proxyTargets.graphql ? "ok" : "error",
+    detail: proxyTargets.graphql ? "GraphQL proxy target configured" : "RASA_PROXY_TARGETS missing graphql",
+  });
+
+  items.push({
+    key: "proxy_target_analytics",
+    status: proxyTargets.analytics ? "ok" : "warning",
+    detail: proxyTargets.analytics ? "Analytics proxy target configured" : "RASA_PROXY_TARGETS missing analytics",
+  });
+
+  const keycloakIssuer = readEnv("KEYCLOAK_ISSUER");
+  const keycloakClientId = readEnv("KEYCLOAK_CLIENT_ID");
+  items.push({
+    key: "keycloak",
+    status: keycloakIssuer && keycloakClientId ? "ok" : "warning",
+    detail:
+      keycloakIssuer && keycloakClientId
+        ? "Keycloak auth configured"
+        : "Keycloak issuer/client ID missing",
+  });
+
+  const cvaBaseUrl = readEnv("CVA_BASE_URL");
+  items.push({
+    key: "cva_base_url",
+    status: cvaBaseUrl ? "ok" : "warning",
+    detail: cvaBaseUrl ? "CVA base URL configured" : "CVA_BASE_URL not set (default fallback in use)",
+  });
+
+  return items;
+}
+
+function computeOverall(
+  services: ServiceHealthItem[],
+  config: ConfigHealthItem[],
+  external: ExternalHealthItem[]
+): HealthStatus {
+  const hasServiceDown = services.some((item) => item.status === "down");
+  const hasServiceMisconfigured = services.some((item) => item.status === "misconfigured");
+  const hasConfigError = config.some((item) => item.status === "error");
+  const hasExternalDown = external.some((item) => item.status === "down");
+  const hasExternalMisconfigured = external.some((item) => item.status === "misconfigured");
+  const hasDegraded = services.some((item) => item.status === "degraded");
+  const hasExternalDegraded = external.some((item) => item.status === "degraded");
+  const hasUnknown = services.some((item) => item.status === "unknown");
+  const hasExternalUnknown = external.some((item) => item.status === "unknown");
+
+  if (hasServiceDown || hasServiceMisconfigured || hasConfigError || hasExternalDown || hasExternalMisconfigured) return "down";
+  if (hasDegraded || hasExternalDegraded) return "degraded";
+  if (hasUnknown || hasExternalUnknown) return "unknown";
+  return "up";
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const identity = getFeedbackIdentityFromSession(session);
+  const isDevRuntime = process.env.NODE_ENV === "development";
+  const canViewFullDiagnostics = isDevRuntime || identity.isAdmin;
+  const accessToken = typeof session.accessToken === "string" ? session.accessToken : null;
+
+  const rasaTargets = getRasaVersionTargets();
+  const rasaChecks = rasaTargets.length > 0
+    ? rasaTargets.map((target) =>
+        probeVersionEndpoint({
+          key: target.key,
+          label: target.label,
+          url: target.url,
+        })
+      )
+    : [
+        Promise.resolve<ServiceHealthItem>({
+          key: "rasa",
+          label: "Rasa",
+          status: "misconfigured",
+          detail: "No Rasa bot URL configured",
+          checkedAt: new Date().toISOString(),
+        }),
+      ];
+
+  const [webapp, action, upstreamGraphql, upstreamAnalytics, upstreamCva, keycloak, ...rasaResults] = await Promise.all([
+    probeVersionEndpoint({ key: "webapp", label: "Webapp", url: getWebappVersionUrl() }),
+    probeVersionEndpoint({ key: "action", label: "Action", url: readEnv("ACTION_VERSION_URL") }),
+    probeExternalGraphql({
+      key: "upstream_graphql",
+      label: "Upstream GraphQL",
+      url: resolveGraphqlUrl(),
+      accessToken,
+    }),
+    probeExternalGet({
+      key: "upstream_analytics",
+      label: "Upstream Analytics REST",
+      url: resolveAnalyticsUrl(),
+      accessToken,
+    }),
+    probeExternalGet({
+      key: "upstream_cva",
+      label: "CVA API",
+      url: resolveCvaThreadsUrl(),
+      accessToken,
+    }),
+    probeExternalGet({
+      key: "keycloak_discovery",
+      label: "Keycloak Discovery",
+      url: resolveKeycloakDiscoveryUrl(),
+    }),
+    ...rasaChecks,
+  ]);
+
+  const config = collectConfigHealth();
+  const services = [webapp, ...rasaResults, action];
+  const external = [upstreamGraphql, upstreamAnalytics, upstreamCva, keycloak];
+  const overall = computeOverall(services, config, external);
+
+  const responseBody: RuntimeHealthResponse = canViewFullDiagnostics
+    ? {
+        checkedAt: new Date().toISOString(),
+        overall,
+        visibility: "full",
+        services,
+        config,
+        external,
+      }
+    : {
+        checkedAt: new Date().toISOString(),
+        overall,
+        visibility: "limited",
+        services: services.map((item) => ({
+          key: item.key,
+          label: item.label,
+          status: item.status,
+          detail: item.status === "up" ? "Service reachable" : "Service health issue detected",
+          checkedAt: item.checkedAt,
+        })),
+        config: [],
+        external: external.map((item) => ({
+          key: item.key,
+          label: item.label,
+          status: item.status,
+          detail: item.status === "up" ? "Endpoint reachable" : "Endpoint health issue detected",
+          checkedAt: item.checkedAt,
+        })),
+      };
+
+  return NextResponse.json(
+    responseBody,
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    }
+  );
+}

--- a/src/components/ui/menus/threadHistoryMenu.tsx
+++ b/src/components/ui/menus/threadHistoryMenu.tsx
@@ -140,7 +140,7 @@ export function SideMenu() {
     } finally {
       setLoading(false);
     }
-  }, [currentThreadId, postThread, setCurrentThreadId, t]);
+  }, [currentThreadId, setCurrentThreadId]);
 
 
   useEffect(() => {

--- a/src/components/ui/menus/topBarMenu.tsx
+++ b/src/components/ui/menus/topBarMenu.tsx
@@ -5,17 +5,21 @@ import { LogOutIcon, Moon, Sun } from "lucide-react"
 import { signOut } from "next-auth/react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useSettingsStore } from "@/store/useSettingsStore";
 import { useTranslation } from "react-i18next";
 import i18n from "../../../i18n";
 import { LANGUAGE_LABELS, SUPPORTED_LANGUAGES } from "@/locales/config";
 import { getFeedbackConfigCached } from "@/lib/feedbackConfigClient";
+import { getRuntimeHealthCached, type RuntimeHealthResponse } from "@/lib/runtimeHealthClient";
 
 
 const baseLanguages: { label: string; value: string }[] = SUPPORTED_LANGUAGES.map((code) => ({ label: LANGUAGE_LABELS[code], value: code }));
 
 export default function TopBar() {
+	const DEV_DIAGNOSTICS = process.env.NODE_ENV === "development";
 	const theme = useSettingsStore((s) => s.theme);
 	const dark = useSettingsStore((s) => s.darkMode);
 	const setDark = useSettingsStore((s) => s.setDarkMode);
@@ -27,6 +31,8 @@ export default function TopBar() {
 	const [botsByLang, setBotsByLang] = useState<Record<string, boolean>>({});
 		const [botLangs, setBotLangs] = useState<string[]>([]);
 	const [canViewFeedbackAdmin, setCanViewFeedbackAdmin] = useState(false);
+	const [serviceHealth, setServiceHealth] = useState<RuntimeHealthResponse | null>(null);
+	const [serviceHealthError, setServiceHealthError] = useState<string | null>(null);
 
 	useEffect(() => {
 		let cancelled = false;
@@ -66,6 +72,79 @@ export default function TopBar() {
 			cancelled = true;
 		};
 	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+
+		const load = async (forceRefresh = false) => {
+			try {
+				const data = await getRuntimeHealthCached(forceRefresh);
+				if (cancelled) return;
+				setServiceHealth(data);
+				setServiceHealthError(null);
+			} catch (error) {
+				if (cancelled) return;
+				setServiceHealthError(error instanceof Error ? error.message : String(error));
+			}
+		};
+
+		void load(true);
+		const intervalId = setInterval(() => {
+			void load(true);
+		}, 20000);
+
+		return () => {
+			cancelled = true;
+			clearInterval(intervalId);
+		};
+	}, []);
+
+	const showDiagnostics = !!serviceHealth || !!serviceHealthError || DEV_DIAGNOSTICS || canViewFeedbackAdmin;
+
+	const healthBadgeClass = (() => {
+		if (!serviceHealth) return "border-slate-500 text-slate-700 dark:text-slate-200";
+		switch (serviceHealth.overall) {
+			case "up":
+				return "border-emerald-500 text-emerald-700 dark:text-emerald-300";
+			case "degraded":
+				return "border-amber-500 text-amber-700 dark:text-amber-300";
+			case "down":
+			case "misconfigured":
+				return "border-rose-500 text-rose-700 dark:text-rose-300";
+			default:
+				return "border-slate-500 text-slate-700 dark:text-slate-200";
+		}
+	})();
+
+	const healthBadgeLabel = (() => {
+		if (serviceHealthError) return "Runtime ?";
+		if (!serviceHealth) return "Runtime ...";
+		if (serviceHealth.overall === "up") return "Runtime up";
+		if (serviceHealth.overall === "degraded") return "Runtime degraded";
+		if (serviceHealth.overall === "down" || serviceHealth.overall === "misconfigured") return "Runtime down";
+		return "Runtime unknown";
+	})();
+
+	const healthTooltipTitle = serviceHealth?.visibility === "full"
+		? "Runtime diagnostics"
+		: "Runtime status";
+
+	const renderStatusClass = (status: string) => {
+		switch (status) {
+			case "up":
+			case "ok":
+				return "text-emerald-300";
+			case "degraded":
+			case "warning":
+				return "text-amber-300";
+			case "down":
+			case "misconfigured":
+			case "error":
+				return "text-rose-300";
+			default:
+				return "text-slate-200";
+		}
+	};
 
 	useEffect(() => {
 		if (theme && theme !== "default") { 
@@ -110,6 +189,76 @@ export default function TopBar() {
 				/>
 			</div>
 			<div className="flex items-center gap-4 ">
+				{showDiagnostics ? (
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Badge variant="outline" className={healthBadgeClass}>
+									{healthBadgeLabel}
+								</Badge>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" align="end" className="max-w-[560px] p-3 space-y-3">
+								<div className="font-semibold">{healthTooltipTitle}</div>
+								{serviceHealthError ? <div>Health check failed: {serviceHealthError}</div> : null}
+								{serviceHealth ? (
+									<>
+										<div className="opacity-90 text-xs">Checked: {new Date(serviceHealth.checkedAt).toLocaleTimeString()}</div>
+										<div className="space-y-1">
+											<div className="font-medium text-xs uppercase tracking-wide opacity-90">Core services</div>
+											{serviceHealth.services.map((svc) => (
+												<div key={svc.key} className="rounded border border-white/15 px-2 py-1.5">
+													<div className="flex items-center justify-between gap-3 text-xs">
+														<span className="font-medium">{svc.label}</span>
+														<span className={renderStatusClass(svc.status)}>{svc.status}</span>
+													</div>
+													<div className="text-[11px] opacity-90 mt-1 break-words">
+														{svc.httpStatus ? `HTTP ${svc.httpStatus} · ` : ""}
+														{svc.latencyMs ? `${svc.latencyMs}ms · ` : ""}
+														{svc.detail}
+													</div>
+												</div>
+											))}
+										</div>
+										{serviceHealth.external.length > 0 ? (
+											<div className="space-y-1 pt-1 border-t border-white/20">
+												<div className="font-medium text-xs uppercase tracking-wide opacity-90">External endpoints</div>
+												{serviceHealth.external.map((ext) => (
+													<div key={ext.key} className="rounded border border-white/15 px-2 py-1.5">
+														<div className="flex items-center justify-between gap-3 text-xs">
+															<span className="font-medium">{ext.label}</span>
+															<span className={renderStatusClass(ext.status)}>{ext.status}</span>
+														</div>
+														<div className="text-[11px] opacity-90 mt-1 break-words">
+															{ext.httpStatus ? `HTTP ${ext.httpStatus} · ` : ""}
+															{ext.latencyMs ? `${ext.latencyMs}ms · ` : ""}
+															{ext.detail}
+														</div>
+													</div>
+												))}
+											</div>
+										) : null}
+										{serviceHealth.visibility === "full" && serviceHealth.config.length > 0 ? (
+											<div className="space-y-1 pt-1 border-t border-white/20">
+												<div className="font-medium text-xs uppercase tracking-wide opacity-90">Config checks</div>
+												{serviceHealth.config.map((cfg) => (
+													<div key={cfg.key} className="rounded border border-white/15 px-2 py-1.5">
+														<div className="flex items-center justify-between gap-3 text-xs">
+															<span className="font-medium">{cfg.key}</span>
+															<span className={renderStatusClass(cfg.status)}>{cfg.status}</span>
+														</div>
+														<div className="text-[11px] opacity-90 mt-1 break-words">{cfg.detail}</div>
+													</div>
+												))}
+											</div>
+										) : null}
+									</>
+								) : (
+									<div>Collecting runtime diagnostics...</div>
+								)}
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				) : null}
 				{canViewFeedbackAdmin ? (
 					<Button variant="outline" className="rounded  hover:bg-black/5" asChild>
 						<Link href="/admin/feedback">Feedback Admin</Link>

--- a/src/components/ui/windows/chatWindow.tsx
+++ b/src/components/ui/windows/chatWindow.tsx
@@ -532,7 +532,7 @@ export default function ChatWindow() {
       closedByCleanup = true;
       es.close();
     };
-  }, [currentThreadId]);
+  }, [addMessage, currentThreadId]);
 
   const sendMessage = async (msg: string) => {
   if (!currentThreadId) return;

--- a/src/components/ui/windows/visualizationWindow.tsx
+++ b/src/components/ui/windows/visualizationWindow.tsx
@@ -23,8 +23,21 @@ export default function VisualizationWindow() {
   const selectedStatIndex = useChatStore((s) => s.selectedStatisticsIndex);
   const { t } = useTranslation('common');
 
-  const showStat = selectedStatIndex !== null && visualization?.stats && visualization.stats[selectedStatIndex];
-  const showChart = selectedIndex !== null && visualization?.charts && visualization.charts[selectedIndex] && !showStat;
+  const activeChartIndex =
+    selectedIndex !== null
+      ? selectedIndex
+      : visualization?.charts && visualization.charts.length > 0
+        ? 0
+        : null;
+  const activeStatIndex =
+    selectedStatIndex !== null
+      ? selectedStatIndex
+      : activeChartIndex === null && visualization?.stats && visualization.stats.length > 0
+        ? 0
+        : null;
+
+  const showStat = activeStatIndex !== null && visualization?.stats && visualization.stats[activeStatIndex];
+  const showChart = activeChartIndex !== null && visualization?.charts && visualization.charts[activeChartIndex] && !showStat;
 
   if (!visualization || (!showChart && !showStat)) {
     return (
@@ -37,7 +50,7 @@ export default function VisualizationWindow() {
 
   if (showStat) {
     const stats = visualization.stats as StatisticalTestResultDTO[];
-    const result = stats[selectedStatIndex];
+    const result = stats[activeStatIndex];
     if (result.test_type === 'MANN_WHITNEY_U_TEST') {
       return <div className="relative h-full w-full overflow-auto p-4"><MannWhitneyUView result={result} /></div>;
     }
@@ -59,11 +72,11 @@ export default function VisualizationWindow() {
 
   const charts = visualization.charts as ChartDTO[];
 
-  if (charts.length === 0 || selectedIndex === null || selectedIndex >= charts.length) {
+  if (charts.length === 0 || activeChartIndex === null || activeChartIndex >= charts.length) {
     return <div className="text-center text-muted-foreground p-4">{t('visualization.none')}</div>;
   }
 
-  const chart: ChartDTO = charts[selectedIndex] as ChartDTO;
+  const chart: ChartDTO = charts[activeChartIndex] as ChartDTO;
 
   let content: ReactElement | null = null;
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -50,9 +50,49 @@ function getSessionSubject(params: {
   return null;
 }
 
+function resolveSafeRedirect(url: string, baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl.trim().replace(/\/$/, "");
+
+  if (!url) {
+    return normalizedBaseUrl;
+  }
+
+  if (url.startsWith("/")) {
+    if (url.startsWith("//")) {
+      return normalizedBaseUrl;
+    }
+    return `${normalizedBaseUrl}${url}`;
+  }
+
+  try {
+    const target = new URL(url);
+    const allowedOrigins = new Set<string>([new URL(normalizedBaseUrl).origin]);
+
+    const configuredNextAuthUrl = process.env.NEXTAUTH_URL?.trim();
+    if (configuredNextAuthUrl) {
+      try {
+        allowedOrigins.add(new URL(configuredNextAuthUrl).origin);
+      } catch {
+        // Ignore invalid NEXTAUTH_URL here; runtime config validation belongs elsewhere.
+      }
+    }
+
+    if (allowedOrigins.has(target.origin)) {
+      return target.toString();
+    }
+  } catch {
+    // Fall back to the base URL on malformed absolute callback URLs.
+  }
+
+  return normalizedBaseUrl;
+}
+
 export const authConfig = {
   ...authBaseConfig,
   callbacks: {
+    async redirect({ url, baseUrl }) {
+      return resolveSafeRedirect(url, baseUrl);
+    },
     async jwt({ token, account }) {
       const sessionSubject = getSessionSubject({
         tokenSub: typeof token.sub === "string" ? token.sub : null,

--- a/src/lib/feedbackStore.ts
+++ b/src/lib/feedbackStore.ts
@@ -133,11 +133,25 @@ function getConfiguredPostgresUrl(): string | null {
   const host = process.env.FEEDBACK_DB_HOST?.trim();
   const database = process.env.FEEDBACK_DB_NAME?.trim();
   const user = process.env.FEEDBACK_DB_USER?.trim();
-  const password = process.env.FEEDBACK_DB_PASSWORD ?? "";
+  const password = process.env.FEEDBACK_DB_PASSWORD?.trim();
   const port = process.env.FEEDBACK_DB_PORT?.trim() || "5432";
+  const hasDiscreteConfig = [
+    process.env.FEEDBACK_DB_HOST,
+    process.env.FEEDBACK_DB_NAME,
+    process.env.FEEDBACK_DB_USER,
+    process.env.FEEDBACK_DB_PASSWORD,
+    process.env.FEEDBACK_DB_PORT,
+    process.env.FEEDBACK_DB_SSL,
+  ].some((value) => typeof value === "string" && value.trim().length > 0);
 
-  if (!host || !database || !user) {
+  if (!hasDiscreteConfig) {
     return null;
+  }
+
+  if (!host || !database || !user || !password) {
+    throw new Error(
+      "FEEDBACK_DB_HOST, FEEDBACK_DB_NAME, FEEDBACK_DB_USER, and FEEDBACK_DB_PASSWORD are required when using FEEDBACK_DB_* configuration"
+    );
   }
 
   const url = new URL(`postgresql://${encodeURIComponent(user)}:${encodeURIComponent(password)}@${host}:${port}/${database}`);

--- a/src/lib/runtimeHealthClient.ts
+++ b/src/lib/runtimeHealthClient.ts
@@ -1,0 +1,75 @@
+export type RuntimeHealthStatus = "up" | "degraded" | "down" | "misconfigured" | "unknown";
+
+export type RuntimeServiceHealthItem = {
+  key: string;
+  label: string;
+  status: RuntimeHealthStatus;
+  detail: string;
+  httpStatus?: number;
+  latencyMs?: number;
+  checkedAt: string;
+};
+
+export type RuntimeConfigHealthItem = {
+  key: string;
+  status: "ok" | "warning" | "error";
+  detail: string;
+};
+
+export type RuntimeExternalHealthItem = {
+  key: string;
+  label: string;
+  status: RuntimeHealthStatus;
+  detail: string;
+  httpStatus?: number;
+  latencyMs?: number;
+  checkedAt: string;
+};
+
+export type RuntimeHealthResponse = {
+  checkedAt: string;
+  overall: RuntimeHealthStatus;
+  visibility: "full" | "limited";
+  services: RuntimeServiceHealthItem[];
+  config: RuntimeConfigHealthItem[];
+  external: RuntimeExternalHealthItem[];
+};
+
+const HEALTH_TTL_MS = 10_000;
+
+let cachedValue: RuntimeHealthResponse | null = null;
+let cachedAt = 0;
+let inflightPromise: Promise<RuntimeHealthResponse> | null = null;
+
+export async function getRuntimeHealthCached(forceRefresh = false): Promise<RuntimeHealthResponse> {
+  const now = Date.now();
+  const cacheFresh = now - cachedAt < HEALTH_TTL_MS;
+
+  if (!forceRefresh && cachedValue && cacheFresh) {
+    return cachedValue;
+  }
+
+  if (!forceRefresh && inflightPromise) {
+    return inflightPromise;
+  }
+
+  inflightPromise = fetch("/api/runtime-health", {
+    method: "GET",
+    cache: "no-store",
+  })
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to load service health (${response.status})`);
+      }
+
+      const payload = (await response.json()) as RuntimeHealthResponse;
+      cachedValue = payload;
+      cachedAt = Date.now();
+      return payload;
+    })
+    .finally(() => {
+      inflightPromise = null;
+    });
+
+  return inflightPromise;
+}


### PR DESCRIPTION
This PR focuses on auth hardening and dependency cleanup in Webapp.

Changes:
- Centralize safe redirect validation so auth callbacks only allow relative paths or same-origin URLs.
- Remove redundant direct dependency pins that are already supplied transitively.
- Keep the lockfile aligned with the manifest changes.

Validation:
- Editor diagnostics passed on the touched auth file.
- The dependency cleanup was checked against actual imports and lockfile usage.