### PR TITLE
Enhance HistoryWindow and chart components for improved analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,15 +2,18 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
 
   - package-ecosystem: docker
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly
 
   - package-ecosystem: npm
     directory: /
+    target-branch: dev
     schedule:
       interval: weekly

--- a/src/app/api/rasa/long-task-callback/route.ts
+++ b/src/app/api/rasa/long-task-callback/route.ts
@@ -167,7 +167,7 @@ export async function POST(req: NextRequest) {
 
   // Publish controls directly so the client can respond to lock/release signals.
   for (const control of controls) {
-    publishToSender(senderId, { type: "control", ...control });
+    publishToSender(senderId, control);
   }
 
   console.info("[long-task-callback] Received callback payload", createTraceLogContext(traceId, {

--- a/src/components/charts/AreaChartView.tsx
+++ b/src/components/charts/AreaChartView.tsx
@@ -57,7 +57,8 @@ export function AreaChartView({ chart }: Props) {
               label={{
                 value: chart.metadata?.y_axis?.label ?? "",
                 angle: -90,
-                position: "insideLeft",
+                position: "center",
+                dx: -20,
               }}
             />
             <Tooltip />
@@ -71,6 +72,7 @@ export function AreaChartView({ chart }: Props) {
                 fill={`hsl(${(i * 70) % 360}, 70%, 50%)`}
                 fillOpacity={0.25}
                 stackId={chart.stacked ? "1" : undefined}
+                isAnimationActive={false}
               />
             ))}
           </RCAreaChart>

--- a/src/components/charts/BarChartView.tsx
+++ b/src/components/charts/BarChartView.tsx
@@ -62,7 +62,8 @@ export function BarChartView({ chart }: Props) {
                   label={{
                     value: chart.metadata?.y_axis?.label ?? "",
                     angle: -90,
-                    position: "insideLeft",
+                    position: "center",
+                    dx: -20,
                   }}
                 />
               </>
@@ -82,7 +83,8 @@ export function BarChartView({ chart }: Props) {
                   label={{
                     value: chart.metadata?.x_axis?.label ?? "",
                     angle: -90,
-                    position: "insideLeft",
+                    position: "center",
+                    dx: -20,
                   }}
                 />
               </>
@@ -95,6 +97,7 @@ export function BarChartView({ chart }: Props) {
                 dataKey={s.name}
                 fill={`hsl(${(i * 70) % 360}, 70%, 50%)`}
                 stackId={chart.stacked ? "1" : undefined}
+                isAnimationActive={false}
               />
             ))}
           </RCBarChart>

--- a/src/components/charts/BoxChartView.tsx
+++ b/src/components/charts/BoxChartView.tsx
@@ -46,12 +46,13 @@ export function BoxChartView({ chart }: Props) {
               label={{
                 value: chart.metadata?.y_axis?.label ?? "",
                 angle: -90,
-                position: "insideLeft",
+                position: "center",
+                dx: -20,
               }}
             />
             <Tooltip />
             <Legend />
-            <Bar dataKey="median" name="Median" fill="hsl(220, 70%, 50%)">
+            <Bar dataKey="median" name="Median" fill="hsl(220, 70%, 50%)" isAnimationActive={false}>
               <ErrorBar dataKey="q1" direction="y" />
             </Bar>
           </BarChart>

--- a/src/components/charts/HistogramChartView.tsx
+++ b/src/components/charts/HistogramChartView.tsx
@@ -46,7 +46,8 @@ export function HistogramChartView({ chart }: Props) {
               label={{
                 value: yLabel,
                 angle: -90,
-                position: "insideLeft",
+                position: "center",
+                dx: -20,
               }}
             />
             <Tooltip />
@@ -55,6 +56,7 @@ export function HistogramChartView({ chart }: Props) {
               dataKey="value"
               name={chart.metadata?.y_axis?.label ?? ""}
               fill="hsl(200, 70%, 50%)"
+              isAnimationActive={false}
             />
           </BarChart>
         </ResponsiveContainer>

--- a/src/components/charts/LineChartView.tsx
+++ b/src/components/charts/LineChartView.tsx
@@ -30,10 +30,10 @@ export function LineChartView({ chart }: Props) {
   );
 
   const data = bins.map((bin) => {
-    const point: Record<string, number | string> = { bin };
+    const point: Record<string, number | string | null> = { bin };
     chart.series.forEach((s) => {
-      const val = s.data.find((p) => String(p.x) === String(bin))?.y ?? NaN;
-      point[s.name] = val;
+      const val = s.data.find((p) => String(p.x) === String(bin))?.y;
+      point[s.name] = typeof val === "number" && val === 0 ? null : (val ?? null);
     });
     return point;
   });
@@ -66,7 +66,8 @@ export function LineChartView({ chart }: Props) {
               label={{
                 value: chart.metadata?.y_axis?.label ?? "",
                 angle: -90,
-                position: "insideLeft",
+                position: "center",
+                dx: -20,
               }}
             />
             <Tooltip />
@@ -78,7 +79,10 @@ export function LineChartView({ chart }: Props) {
                 dataKey={s.name}
                 stroke={`hsl(${(i * 70) % 360}, 70%, 50%)`}
                 strokeWidth={2}
-                dot={false}
+                dot={{ r: 10 }}
+                activeDot={{ r: 15 }}
+                connectNulls={false}
+                isAnimationActive={false}
               />
             ))}
           </LineChart>

--- a/src/components/charts/MannWhitneyUThumbnail.tsx
+++ b/src/components/charts/MannWhitneyUThumbnail.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { AlertCircle, CheckCircle2, SkipForward } from 'lucide-react';
+import type { StatisticalTestResultDTO } from '@/models/dto/response';
+
+interface MannWhitneyUThumbnailProps {
+  result: StatisticalTestResultDTO;
+}
+
+export function MannWhitneyUThumbnail({ result }: MannWhitneyUThumbnailProps) {
+  if (result.status === 'skipped') {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-lg  p-3">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <SkipForward className="h-5 w-5 text-yellow-600" />
+          <div className="text-xs font-semibold">Skipped</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (result.status === 'error') {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-lg p-3 text-red-900">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <AlertCircle className="h-5 w-5 text-red-600" />
+          <div className="text-xs font-semibold">Error</div>
+        </div>
+      </div>
+    );
+  }
+
+  const passed = result.passed === true;
+  const significanceLabel =
+    result.status === 'success' ? (passed ? 'Significant' : 'Not significant') : result.status;
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3 rounded-lg  p-3 text-center">
+      <div className="flex items-center gap-2">
+        {passed ? (
+          <CheckCircle2 className="h-5 w-5 text-green-600" />
+        ) : (
+          <AlertCircle className="h-5 w-5 text-red-600/50" />
+        )}
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Mann-Whitney U
+        </div>
+      </div>
+
+      <div className="text-lg font-bold text-foreground">
+        p = {result.p_value?.toFixed(3) || 'N/A'}
+      </div>
+
+      <div className="rounded-full border bg-muted/40 px-2.5 py-1 text-[10px] font-medium text-muted-foreground">
+        {significanceLabel}
+      </div>
+    </div>
+  );
+}

--- a/src/components/charts/MannWhitneyUView.tsx
+++ b/src/components/charts/MannWhitneyUView.tsx
@@ -76,7 +76,7 @@ export function MannWhitneyUView({ result }: MannWhitneyUViewProps) {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b">
-                <th className="text-left py-2 px-3 font-semibold">Metric</th>
+                <th></th>
                 <th className="text-center py-2 px-3 font-semibold">{details.cohort_a_label || 'Cohort A'}</th>
                 <th className="text-center py-2 px-3 font-semibold">{details.cohort_b_label || 'Cohort B'}</th>
               </tr>

--- a/src/components/charts/PieChartView.tsx
+++ b/src/components/charts/PieChartView.tsx
@@ -32,6 +32,7 @@ export function PieChartView({ chart }: Props) {
               outerRadius={80}
               innerRadius={chart.donut ? 50 : 0}
               label
+              isAnimationActive={false}
             >
               {chart.data.map((s, i) => (
                 <Cell

--- a/src/components/charts/RadarChartView.tsx
+++ b/src/components/charts/RadarChartView.tsx
@@ -45,6 +45,7 @@ export function RadarChartView({ chart }: Props) {
                 stroke={`hsl(${(i * 70) % 360}, 70%, 50%)`}
                 fill={`hsl(${(i * 70) % 360}, 70%, 50%)`}
                 fillOpacity={0.3}
+                isAnimationActive={false}
               />
             ))}
           </RCRadarChart>

--- a/src/components/charts/ScatterChartView.tsx
+++ b/src/components/charts/ScatterChartView.tsx
@@ -48,7 +48,8 @@ export function ScatterChartView({ chart }: Props) {
               label={{
                 value: chart.metadata?.y_axis?.label ?? "",
                 angle: -90,
-                position: "insideLeft",
+                position: "center",
+                dx: -20,
               }}
             />
             <Tooltip cursor={{ strokeDasharray: "3 3" }} />
@@ -60,6 +61,7 @@ export function ScatterChartView({ chart }: Props) {
                 dataKey="y"
                 data={data.filter((d) => d.series === series.name)}
                 fill={`hsl(${(index * 70) % 360}, 70%, 50%)`}
+                isAnimationActive={false}
               />
             ))}
           </ScatterChart>

--- a/src/components/charts/WaterfallChartView.tsx
+++ b/src/components/charts/WaterfallChartView.tsx
@@ -52,7 +52,8 @@ export function WaterfallChartView({ chart }: Props) {
               label={{
                 value: chart.metadata?.y_axis?.label ?? "",
                 angle: -90,
-                position: "insideLeft",
+                position: "center",
+                dx: -20,
               }}
             />
             <Tooltip />
@@ -61,6 +62,7 @@ export function WaterfallChartView({ chart }: Props) {
               dataKey="value"
               name={chart.metadata?.y_axis?.label ?? ""}
               fill="hsl(140, 70%, 45%)"
+              isAnimationActive={false}
             />
           </BarChart>
         </ResponsiveContainer>

--- a/src/components/charts/chart-thumbnail-view.tsx
+++ b/src/components/charts/chart-thumbnail-view.tsx
@@ -43,10 +43,10 @@ export function LineChartThumbnail({ chart }: { chart: LineChartDTO }) {
   );
 
   const data = bins.map((bin) => {
-    const point: Record<string, number | string> = { bin };
+    const point: Record<string, number | string | null> = { bin };
     chart.series.forEach((s) => {
-      const val = s.data.find((p) => String(p.x) === String(bin))?.y ?? NaN;
-      point[s.name] = val;
+      const val = s.data.find((p) => String(p.x) === String(bin))?.y;
+      point[s.name] = typeof val === "number" && val === 0 ? null : (val ?? null);
     });
     return point;
   });
@@ -62,6 +62,7 @@ export function LineChartThumbnail({ chart }: { chart: LineChartDTO }) {
             stroke={`hsl(${(i * 70) % 360}, 70%, 50%)`}
             strokeWidth={2}
             dot={false}
+            connectNulls={false}
             isAnimationActive={false}
           />
         ))}

--- a/src/components/ui/windows/chatWindow.tsx
+++ b/src/components/ui/windows/chatWindow.tsx
@@ -334,8 +334,19 @@ export default function ChatWindow() {
     if (isVisualizationResponseDTO(custom)) {
       setVisualization(custom);
       addToHistory(custom);
-      setSelectedStatisticsIndex(null);
-      setSelectedChartIndex(0);
+      const chartCount = custom.charts?.length ?? 0;
+      const statCount = custom.stats?.length ?? 0;
+
+      if (chartCount > 0) {
+        setSelectedStatisticsIndex(null);
+        setSelectedChartIndex(0);
+      } else if (statCount > 0) {
+        setSelectedChartIndex(null);
+        setSelectedStatisticsIndex(0);
+      } else {
+        setSelectedChartIndex(null);
+        setSelectedStatisticsIndex(null);
+      }
     }
   }, [emitPlanDebugMessage]);
 

--- a/src/components/ui/windows/historyWindow.tsx
+++ b/src/components/ui/windows/historyWindow.tsx
@@ -9,6 +9,7 @@ import clsx from "clsx";
 import { useTranslation } from 'react-i18next';
 import '@/i18n';
 import { ChartThumbnail } from "@/components/ui/chart-thumbnail";
+import { MannWhitneyUThumbnail } from "@/components/charts/MannWhitneyUThumbnail";
 import { useThread } from "@/components/ThreadContext";
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "../tooltip";
 
@@ -251,10 +252,29 @@ export default function HistoryWindow() {
                           isSelected ? "ring-3 ring-blue-500 scale-[1.02]" : "hover:ring- hover:ring-muted"
                         )}
                       >
-                        <div className="w-full h-full flex flex-col justify-between border hover:bg-black/5 p-3">
-                          <div className="text-xs uppercase text-muted-foreground">{t('visualization.title')}</div>
-                          <div className="text-sm font-semibold line-clamp-2">{item.title || item.test_type}</div>
-                          <div className="text-xs text-muted-foreground">{statusLabel}</div>
+                        <div className="w-full h-full flex flex-col justify-between border hover:bg-black/5">
+                          <div className="w-full flex-1 min-w-0 flex items-center justify-center overflow-hidden p-3">
+                            <div className="w-4/5 h-4/5">
+                              {item.test_type === 'MANN_WHITNEY_U_TEST' ? (
+                                <MannWhitneyUThumbnail result={item} />
+                              ) : (
+                                <div className="flex h-full w-full items-center justify-center rounded-lg border bg-muted/30 p-3 text-center">
+                                  <div>
+                                    <div className="text-xs font-semibold uppercase text-muted-foreground">
+                                      {t('visualization.title')}
+                                    </div>
+                                    <div className="mt-2 text-sm font-semibold line-clamp-2">
+                                      {item.title || item.test_type}
+                                    </div>
+                                  </div>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="p-3 text-sm flex flex-col flex-shrink-0 flex-grow-0">
+                            <div className="font-semibold truncate">{item.title || item.test_type}</div>
+                            <div className="text-xs text-muted-foreground truncate">{statusLabel}</div>
+                          </div>
                         </div>
                       </div>
                     </TooltipTrigger>

--- a/src/components/ui/windows/visualizationWindow.tsx
+++ b/src/components/ui/windows/visualizationWindow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ReactElement } from "react";
+import { useEffect, type ReactElement } from "react";
 import { useChatStore } from "@/store/useChatStore";
 import type { ChartDTO } from "@/models/dto/charts";
 import { LineChartView } from "@/components/charts/LineChartView";
@@ -15,26 +15,29 @@ import { BoxChartView } from "@/components/charts/BoxChartView";
 import type { StatisticalTestResultDTO } from "@/models/dto/response";
 import { MannWhitneyUView } from "@/components/charts/MannWhitneyUView";
 import { useTranslation } from 'react-i18next';
+import { useThread } from "@/components/ThreadContext";
 import '@/i18n';
 
 export default function VisualizationWindow() {
+  const { currentThreadId } = useThread();
   const visualization = useChatStore((s) => s.visualization);
+  const setVisualization = useChatStore((s) => s.setVisualization);
   const selectedIndex = useChatStore((s) => s.selectedChartIndex);
+  const setSelectedChartIndex = useChatStore((s) => s.setSelectedChartIndex);
   const selectedStatIndex = useChatStore((s) => s.selectedStatisticsIndex);
+  const setSelectedStatisticsIndex = useChatStore((s) => s.setSelectedStatisticsIndex);
   const { t } = useTranslation('common');
 
-  const activeChartIndex =
-    selectedIndex !== null
-      ? selectedIndex
-      : visualization?.charts && visualization.charts.length > 0
-        ? 0
-        : null;
-  const activeStatIndex =
-    selectedStatIndex !== null
-      ? selectedStatIndex
-      : activeChartIndex === null && visualization?.stats && visualization.stats.length > 0
-        ? 0
-        : null;
+  useEffect(() => {
+    if (currentThreadId === null) {
+      setVisualization(null);
+      setSelectedChartIndex(null);
+      setSelectedStatisticsIndex(null);
+    }
+  }, [currentThreadId, setSelectedChartIndex, setSelectedStatisticsIndex, setVisualization]);
+
+  const activeChartIndex = selectedIndex;
+  const activeStatIndex = selectedStatIndex;
 
   const showStat = activeStatIndex !== null && visualization?.stats && visualization.stats[activeStatIndex];
   const showChart = activeChartIndex !== null && visualization?.charts && visualization.charts[activeChartIndex] && !showStat;


### PR DESCRIPTION
This pull request introduces several improvements to chart rendering, user interface consistency, and statistical test result display. The main changes include standardizing axis label positions across chart types, disabling chart animations for improved performance and predictability, enhancing the display of statistical test results (especially for Mann-Whitney U tests), and refining state management for chart/statistic selection. Additionally, the Dependabot configuration is updated to target the `dev` branch.

**Chart rendering and UI consistency:**

* Standardized all y-axis (and some x-axis) label positions to `"center"` with a horizontal offset (`dx: -20`) across all chart components, improving label visibility and alignment. [[1]](diffhunk://#diff-b6e69ff7ea90e9c393d3d938a113fd959f6e61c4375f7f6efb492d4bb4c64e3bL60-R61) [[2]](diffhunk://#diff-afb4c57846a2b7931ef66df7b7334817469bd51ef7d839e1844da4e7188cfe48L65-R66) [[3]](diffhunk://#diff-afb4c57846a2b7931ef66df7b7334817469bd51ef7d839e1844da4e7188cfe48L85-R87) [[4]](diffhunk://#diff-4a99c4289222c9bb6c61fc1044b756712fdb98aa99ee0c232d1d5ee5ad35135bL49-R55) [[5]](diffhunk://#diff-f7391709ccbf170895e8efc774447c5ac757494628307a6f24b40e8267a92decL49-R50) [[6]](diffhunk://#diff-a3390e6e6257e3b3a0504fdc12c08b7fc82da1c789071104354b4839e890cc6bL51-R52) [[7]](diffhunk://#diff-130b3a2cfd4b6d6deecb65199eb9f30ea94e3c872d7b3c9b366fd021c613fcacL55-R56) [[8]](diffhunk://#diff-b2ad917548a180d996a1c165ff0002c0fdf2420e50b0a2e4f8ca22138d206a01L69-R70)
* Disabled chart animations by setting `isAnimationActive={false}` on all chart elements for better performance and more predictable rendering, especially in thumbnails and history views. [[1]](diffhunk://#diff-b6e69ff7ea90e9c393d3d938a113fd959f6e61c4375f7f6efb492d4bb4c64e3bR75) [[2]](diffhunk://#diff-afb4c57846a2b7931ef66df7b7334817469bd51ef7d839e1844da4e7188cfe48R100) [[3]](diffhunk://#diff-4a99c4289222c9bb6c61fc1044b756712fdb98aa99ee0c232d1d5ee5ad35135bL49-R55) [[4]](diffhunk://#diff-f7391709ccbf170895e8efc774447c5ac757494628307a6f24b40e8267a92decR59) [[5]](diffhunk://#diff-8f337662ce8f5680f95e966ed851e765de156415c54fe8532b4c203e4ce54394R35) [[6]](diffhunk://#diff-fdf820c300ef01848d71bfd67fd7038eefd2252d552964ac0cb28a356d098a83R48) [[7]](diffhunk://#diff-a3390e6e6257e3b3a0504fdc12c08b7fc82da1c789071104354b4839e890cc6bR64) [[8]](diffhunk://#diff-130b3a2cfd4b6d6deecb65199eb9f30ea94e3c872d7b3c9b366fd021c613fcacR65) [[9]](diffhunk://#diff-cce3a0e1d55537cd54caad194c50aec42661233f756dceb41bd9c80423a023abR65) [[10]](diffhunk://#diff-b2ad917548a180d996a1c165ff0002c0fdf2420e50b0a2e4f8ca22138d206a01L81-R85)
* Improved handling of zero values and nulls in line charts and thumbnails to prevent misleading visual connections and ensure missing data is represented accurately. [[1]](diffhunk://#diff-b2ad917548a180d996a1c165ff0002c0fdf2420e50b0a2e4f8ca22138d206a01L33-R36) [[2]](diffhunk://#diff-cce3a0e1d55537cd54caad194c50aec42661233f756dceb41bd9c80423a023abL46-R49) [[3]](diffhunk://#diff-b2ad917548a180d996a1c165ff0002c0fdf2420e50b0a2e4f8ca22138d206a01L81-R85) [[4]](diffhunk://#diff-cce3a0e1d55537cd54caad194c50aec42661233f756dceb41bd9c80423a023abR65)

**Statistical test results and visualization:**

* Added a new `MannWhitneyUThumbnail` component for a consistent and informative summary display of Mann-Whitney U test results in history and thumbnail views, including status icons and p-value display. [[1]](diffhunk://#diff-29b59db2b3b4686cb30455079fdd8307f8716635db96ce7f862d11bf50891431R1-R59) [[2]](diffhunk://#diff-569e372d0272dda20b4dee29382c6a696365e49a71595dc9582ad0a367b65f66R12) [[3]](diffhunk://#diff-569e372d0272dda20b4dee29382c6a696365e49a71595dc9582ad0a367b65f66L254-R277)
* Updated the `MannWhitneyUView` table to remove the "Metric" header for a cleaner look.

**State management and selection logic:**

* Improved selection logic in the chat window and visualization window to ensure that when new visualizations are loaded, the first chart or statistic is automatically selected, and selections are reset when switching threads. [[1]](diffhunk://#diff-cc4f03ecdca2a6ac90600d123ce5272d5d05c292efa4ce9ffadddb68388dacc8R289-R301) [[2]](diffhunk://#diff-623b1f7b9e1537a08c0766431a6c6593d389934014ec35b9cd9ee372551f4a2fL3-R3) [[3]](diffhunk://#diff-623b1f7b9e1537a08c0766431a6c6593d389934014ec35b9cd9ee372551f4a2fR18-R40)

**Configuration updates:**

* Updated `.github/dependabot.yml` to set `target-branch: dev` for all package ecosystems, ensuring dependency updates are proposed against the correct branch.