### PR TITLE
fix(docker): include SSOT data in runtime image and CI checkout

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           ref: ${{ github.event.inputs.target_ref || github.ref }}
+          submodules: recursive
         
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN mkdir -p /app/.data && chown -R node:node /app && chmod 700 /app/.data
 COPY --from=builder --chown=node:node /app/.next/standalone ./
 COPY --from=builder --chown=node:node /app/.next/static ./.next/static
 COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=builder --chown=node:node /app/src/shared/SSOT ./src/shared/SSOT
 
 ENV WEBAPP_VERSION=${WEBAPP_VERSION}
 ENV WEBAPP_COMMIT_SHA=${WEBAPP_COMMIT_SHA}


### PR DESCRIPTION
This pull request includes updates to the Docker build process and the Dockerfile to ensure proper inclusion of submodules and required shared resources. The most important changes are:

**Docker Build Process Improvements:**

* Updated the `actions/checkout` step in `.github/workflows/docker-build.yml` to include submodules recursively during the checkout, ensuring all git submodules are available in the build context.

**Dockerfile Resource Inclusion:**

* Added a `COPY` command in the `Dockerfile` to include the `SSOT` directory from `src/shared` in the final image, ensuring this shared resource is available at runtime.