### PR TITLE
feat(ci): add auto/manual immutable tags while keeping channel tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,22 +65,38 @@ jobs:
           BRANCH_NAME="${TARGET_REF:-${{ github.ref_name }}}"
           SAFE_BRANCH="$(echo "${BRANCH_NAME//\//-}" | tr '[:upper:]' '[:lower:]')"
 
+          if [ -z "$SAFE_BRANCH" ]; then
+            SAFE_BRANCH="manual"
+          fi
+
+          BUILD_SOURCE="auto"
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            if [ -z "$SAFE_BRANCH" ]; then
-              SAFE_BRANCH="manual"
-            fi
-            BUILD_ARGS+=(--build-arg WEBAPP_IMAGE_TAG=${SAFE_BRANCH}-manual)
-            TAG_ARGS=(-t ghcr.io/$REPO_NAME_LC:${SAFE_BRANCH}-manual -t ghcr.io/$REPO_NAME_LC:${SAFE_BRANCH}-$SHORT_SHA)
-          elif [ "$SAFE_BRANCH" = "master" ]; then
-            BUILD_ARGS+=(--build-arg WEBAPP_IMAGE_TAG=latest)
-            TAG_ARGS=(-t ghcr.io/$REPO_NAME_LC:latest -t ghcr.io/$REPO_NAME_LC:master-$SHORT_SHA)
+            BUILD_SOURCE="manual"
+          fi
+
+          if [ "$SAFE_BRANCH" = "master" ]; then
+            IMAGE_TAG="latest"
+            IMAGE_SHA_TAG="master-$SHORT_SHA"
+            IMAGE_SOURCE_TAG="master-$BUILD_SOURCE-$SHORT_SHA"
           elif [ "$SAFE_BRANCH" = "dev" ]; then
-            BUILD_ARGS+=(--build-arg WEBAPP_IMAGE_TAG=dev)
-            TAG_ARGS=(-t ghcr.io/$REPO_NAME_LC:dev -t ghcr.io/$REPO_NAME_LC:dev-$SHORT_SHA)
+            IMAGE_TAG="dev"
+            IMAGE_SHA_TAG="dev-$SHORT_SHA"
+            IMAGE_SOURCE_TAG="dev-$BUILD_SOURCE-$SHORT_SHA"
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            IMAGE_TAG="$SAFE_BRANCH"
+            IMAGE_SHA_TAG="$SAFE_BRANCH-$SHORT_SHA"
+            IMAGE_SOURCE_TAG="$SAFE_BRANCH-$BUILD_SOURCE-$SHORT_SHA"
           else
             echo "Unsupported branch for docker publish: $SAFE_BRANCH" >&2
             exit 1
           fi
+
+          BUILD_ARGS+=(--build-arg WEBAPP_IMAGE_TAG=$IMAGE_TAG)
+          TAG_ARGS=(
+            -t ghcr.io/$REPO_NAME_LC:$IMAGE_TAG
+            -t ghcr.io/$REPO_NAME_LC:$IMAGE_SHA_TAG
+            -t ghcr.io/$REPO_NAME_LC:$IMAGE_SOURCE_TAG
+          )
 
           DOCKER_OUTPUT_FLAG="--push"
           ATTEST_ARGS=(--provenance=mode=max --sbom=true)


### PR DESCRIPTION
This pull request updates the Docker image tagging logic in the GitHub Actions workflow to provide more consistent and informative tags for each build, including the build source (manual or automatic) and commit SHA. The changes ensure that images for `master`, `dev`, and manually triggered builds are tagged with additional metadata, improving traceability and clarity of image origins.

**Improvements to Docker image tagging and build logic:**

* Refactored the tagging logic to always include three tags for each image: a simple tag (e.g., `latest` or `dev`), a SHA-specific tag (e.g., `master-<sha>`), and a tag that includes both the branch and build source (e.g., `master-manual-<sha>`), improving traceability of images.
* Introduced a `BUILD_SOURCE` variable to distinguish between manual (`workflow_dispatch`) and automatic builds, and incorporated this into the image tags for better clarity on build provenance.
* Simplified and unified the logic for assigning build arguments and tags, reducing repeated code and making the workflow easier to maintain.