### PR TITLE
chore(ci): simplify docker tags to channel and sha

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -69,23 +69,15 @@ jobs:
             SAFE_BRANCH="manual"
           fi
 
-          BUILD_SOURCE="auto"
-          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            BUILD_SOURCE="manual"
-          fi
-
           if [ "$SAFE_BRANCH" = "master" ]; then
             IMAGE_TAG="latest"
             IMAGE_SHA_TAG="master-$SHORT_SHA"
-            IMAGE_SOURCE_TAG="master-$BUILD_SOURCE-$SHORT_SHA"
           elif [ "$SAFE_BRANCH" = "dev" ]; then
             IMAGE_TAG="dev"
             IMAGE_SHA_TAG="dev-$SHORT_SHA"
-            IMAGE_SOURCE_TAG="dev-$BUILD_SOURCE-$SHORT_SHA"
           elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             IMAGE_TAG="$SAFE_BRANCH"
             IMAGE_SHA_TAG="$SAFE_BRANCH-$SHORT_SHA"
-            IMAGE_SOURCE_TAG="$SAFE_BRANCH-$BUILD_SOURCE-$SHORT_SHA"
           else
             echo "Unsupported branch for docker publish: $SAFE_BRANCH" >&2
             exit 1
@@ -95,7 +87,6 @@ jobs:
           TAG_ARGS=(
             -t ghcr.io/$REPO_NAME_LC:$IMAGE_TAG
             -t ghcr.io/$REPO_NAME_LC:$IMAGE_SHA_TAG
-            -t ghcr.io/$REPO_NAME_LC:$IMAGE_SOURCE_TAG
           )
 
           DOCKER_OUTPUT_FLAG="--push"


### PR DESCRIPTION
This pull request simplifies the Docker image tagging logic in the `.github/workflows/docker-build.yml` workflow. The main change is the removal of the `BUILD_SOURCE` and `IMAGE_SOURCE_TAG` variables, which streamlines the tagging process and reduces unnecessary complexity.

**Docker image tagging simplification:**

* Removed the `BUILD_SOURCE` and `IMAGE_SOURCE_TAG` variables and their associated logic, so images are now tagged only with the standard tags (`IMAGE_TAG` and `IMAGE_SHA_TAG`) instead of an additional source-based tag.
* Updated the `TAG_ARGS` array to exclude the `IMAGE_SOURCE_TAG`, ensuring only the relevant tags are applied to built images.