### PR TITLE
Fix ResizablePanel sizes and optimize card height calculation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
               </div>
             </ResizablePanel>
             <ResizableHandle className="min-h-1 bg-transparent" />
-            <ResizablePanel defaultSize="25%" minSize="20%" collapsible>
+            <ResizablePanel defaultSize="25%" minSize="25%" maxSize="25%" collapsible>
               <div className="flex h-full items-center justify-center p-2">
                 <Card className="h-full w-full p-0">
                     <CardContent className="h-full w-full p-2">

--- a/src/components/ui/windows/historyWindow.tsx
+++ b/src/components/ui/windows/historyWindow.tsx
@@ -14,6 +14,8 @@ import { useThread } from "@/components/ThreadContext";
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "../tooltip";
 
 export default function HistoryWindow() {
+  const cardAspectRatio = 6 / 4;
+  const historyRowPadding = 16;
   const { currentThreadId } = useThread();
   const history = useChatStore((s) => s.history);
   const setHistory = useChatStore((s) => s.setHistory);
@@ -114,49 +116,38 @@ export default function HistoryWindow() {
 
 
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [cardHeight, setCardHeight] = useState<number>(0);
 
   useEffect(() => {
-    const updateDimensions = () => {
-      if (containerRef.current) {
-        const { width, height } = containerRef.current.getBoundingClientRect();
-        setContainerDimensions({ width, height });
-      }
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+
+    const updateCardHeight = () => {
+      setCardHeight(Math.max(viewport.clientHeight - historyRowPadding, 0));
     };
 
-    const observedElement = containerRef.current;
-    let resizeObserver: ResizeObserver | null = null;
-    if (observedElement) {
-      resizeObserver = new ResizeObserver(updateDimensions);
-      resizeObserver.observe(observedElement);
-    }
-    updateDimensions();
+    updateCardHeight();
 
-    window.addEventListener("resize", updateDimensions);
+    const resizeObserver = new ResizeObserver(() => {
+      updateCardHeight();
+    });
+
+    resizeObserver.observe(viewport);
 
     return () => {
-      window.removeEventListener("resize", updateDimensions);
-      if (resizeObserver && observedElement) {
-        resizeObserver.unobserve(observedElement);
-      }
+      resizeObserver.disconnect();
     };
   }, []);
-
-  const cardHeight = Math.max(100, containerDimensions.height - 60);
-  const cardWidth = Math.max(180, cardHeight * 0.75);
-  
-  const scrollRef = useRef<HTMLDivElement>(null);
 
   return (
     <div ref={containerRef} className="w-full h-full flex flex-col p-4">
       <p className=" font-semibold text-primary">{t('history.title')}</p>
       <ScrollArea
-        ref={scrollRef}
+        viewportRef={viewportRef}
         className="w-full flex-1"
         onWheel={(e) => {
-          const viewport = scrollRef.current?.querySelector(
-          "[data-radix-scroll-area-viewport]"
-          ) as HTMLDivElement | null;
+          const viewport = viewportRef.current;
 
           if (!viewport) return;
 
@@ -166,7 +157,7 @@ export default function HistoryWindow() {
           }
         }}
       >
-        <div ref={scrollRef}className="flex flex-1 flex-row gap-2 p-2">
+        <div className="box-border flex h-full min-h-0 flex-row items-stretch gap-2 overflow-y-hidden p-2">
           <TooltipProvider>
             {history.map((viz, historyIndex) => {
               const charts = (viz.charts ?? []) as ChartDTO[];
@@ -187,16 +178,16 @@ export default function HistoryWindow() {
                         }}
                         onClick={() => handleChartClick(viz, chartIndex)}
                         style={{
-                          width: `${cardWidth}px`,
-                          height: `${cardHeight}px`,
+                          height: cardHeight > 0 ? `${cardHeight}px` : undefined,
+                          width: cardHeight > 0 ? `${cardHeight * cardAspectRatio}px` : undefined,
                         }}
                         className={clsx(
-                          "cursor-pointer transition-all duration-300 flex-shrink-0 min-h-0 flex items-center justify-center ",
+                          "flex min-h-0 flex-shrink-0 cursor-pointer items-stretch justify-center transition-all duration-300",
                           isSelected ? "ring-3 ring-blue-500 scale-[1.02]" : "hover:ring- hover:ring-muted"
                         )}
                       >
-                        <div className="w-full h-full flex flex-col justify-between border hover:bg-black/5">
-                          <div className="w-full flex-1 min-w-0 flex items-center justify-center overflow-hidden">
+                        <div className="flex h-full w-full min-h-0 flex-col justify-between border hover:bg-black/5">
+                          <div className="flex min-h-0 w-full min-w-0 flex-1 items-center justify-center overflow-hidden">
                             <div className="w-4/5 h-4/5">
                               <ChartThumbnail chart={item} />
                             </div>
@@ -246,16 +237,16 @@ export default function HistoryWindow() {
                         }}
                         onClick={() => handleStatClick(viz, statIndex)}
                         style={{
-                          width: `${cardWidth}px`,
-                          height: `${cardHeight}px`,
+                          height: cardHeight > 0 ? `${cardHeight}px` : undefined,
+                          width: cardHeight > 0 ? `${cardHeight * cardAspectRatio}px` : undefined,
                         }}
                         className={clsx(
-                          "cursor-pointer transition-all duration-300 flex-shrink-0 min-h-0 flex items-center justify-center ",
+                          "flex min-h-0 flex-shrink-0 cursor-pointer items-stretch justify-center transition-all duration-300",
                           isSelected ? "ring-3 ring-blue-500 scale-[1.02]" : "hover:ring- hover:ring-muted"
                         )}
                       >
-                        <div className="w-full h-full flex flex-col justify-between border hover:bg-black/5">
-                          <div className="w-full flex-1 min-w-0 flex items-center justify-center overflow-hidden p-3">
+                        <div className="flex h-full w-full min-h-0 flex-col justify-between border hover:bg-black/5">
+                          <div className="flex min-h-0 w-full min-w-0 flex-1 items-center justify-center overflow-hidden p-3">
                             <div className="w-4/5 h-4/5">
                               {item.test_type === 'MANN_WHITNEY_U_TEST' ? (
                                 <MannWhitneyUThumbnail result={item} />


### PR DESCRIPTION
This pull request improves the layout and resizing behavior of the `HistoryWindow` component and makes a minor adjustment to a panel in the `HomePage`. The main focus is on ensuring that history cards maintain a consistent aspect ratio and dynamically size themselves based on the available viewport, resulting in a more responsive and visually consistent UI.

**UI and Layout Improvements:**

* Refactored the `HistoryWindow` component to calculate card dimensions based on the viewport's height, maintaining a consistent 6:4 aspect ratio and updating dynamically with a `ResizeObserver`. This replaces the previous fixed minimums and manual resize handling. [[1]](diffhunk://#diff-569e372d0272dda20b4dee29382c6a696365e49a71595dc9582ad0a367b65f66R17-R18) [[2]](diffhunk://#diff-569e372d0272dda20b4dee29382c6a696365e49a71595dc9582ad0a367b65f66L117-R150)
* Updated the card container and card styling in `HistoryWindow` to use more robust flexbox layouts, ensuring cards stretch appropriately and overflow is handled cleanly. [[1]](diffhunk://#diff-569e372d0272dda20b4dee29382c6a696365e49a71595dc9582ad0a367b65f66L169-R160) [[2]](diffhunk://#diff-569e372d0272dda20b4dee29382c6a696365e49a71595dc9582ad0a367b65f66L190-R190) [[3]](diffhunk://#diff-569e372d0272dda20b4dee29382c6a696365e49a71595dc9582ad0a367b65f66L249-R249)
* Updated the `ResizablePanel` in `HomePage` to have a fixed size of 25% (min, max, and default), preventing it from being resized outside this range.

**Code Maintenance:**

* Updated the `src/shared/SSOT` submodule to the latest commit