### PR TITLE
Derive ChartType from a const array, add SSOT drift-guard test

### DIFF
--- a/src/models/dto/types.ts
+++ b/src/models/dto/types.ts
@@ -1,13 +1,19 @@
-export type ChartType =
-  | "LINE"
-  | "BAR"
-  | "BOX"
-  | "HISTOGRAM"
-  | "SCATTER"
-  | "PIE"
-  | "RADAR"
-  | "WATERFALL"
-  | "AREA";
+// Kept in sync with SSOT/ChartType.yml's canonical values -- see
+// tests/lib/chartType.test.ts, which fails if this list and that file
+// diverge.
+export const CHART_TYPES = [
+  "LINE",
+  "BAR",
+  "BOX",
+  "HISTOGRAM",
+  "SCATTER",
+  "PIE",
+  "RADAR",
+  "WATERFALL",
+  "AREA",
+] as const;
+
+export type ChartType = (typeof CHART_TYPES)[number];
 
 export interface ChartPoint {
   x: string | number;

--- a/tests/lib/chartType.test.ts
+++ b/tests/lib/chartType.test.ts
@@ -1,0 +1,26 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+import { CHART_TYPES } from "@/models/dto/types";
+
+type SsotEntry = {
+  canonical?: string;
+};
+
+describe("CHART_TYPES", () => {
+  it("matches SSOT/ChartType.yml's canonical values exactly", async () => {
+    const filePath = path.join(process.cwd(), "src", "shared", "SSOT", "ChartType.yml");
+    const content = await fs.readFile(filePath, "utf-8");
+    const parsed = YAML.parse(content) as SsotEntry[];
+
+    const ssotCanonicals = parsed
+      .map((entry) => entry.canonical)
+      .filter((value): value is string => typeof value === "string")
+      .sort();
+
+    const chartTypes = [...CHART_TYPES].sort();
+
+    expect(chartTypes).toEqual(ssotCanonicals);
+  });
+});


### PR DESCRIPTION
ChartType was a hand-typed TS union duplicating ChartType.yml's canonicals — currently in sync (9/9) but nothing would catch future drift. A TS union is compile-time, so unlike the Python-side fixes there's no runtime loader call to swap in; full codegen felt disproportionate for a 9-value, near-static enum. Converted ChartType to be derived from a const array (standard TS idiom, same resulting type, zero runtime cost — Extract<ChartType, "LINE"> etc. in charts.ts unaffected) and added one test that diffs it against ChartType.yml at test time. tsc --noEmit clean, full suite green (64/64).